### PR TITLE
Fixed missing imports in classification_with_NODE notebook

### DIFF
--- a/examples/classification_with_NODE.ipynb
+++ b/examples/classification_with_NODE.ipynb
@@ -3,31 +3,10 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "import os\n",
     "os.chdir(\"..\")\n",
     "from sklearn.datasets import fetch_covtype\n",
-    "import random\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import lightgbm as lgb\n",
-    "from sklearn.metrics import accuracy_score, f1_score\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
-   "source": [
     "from sklearn.datasets import make_classification\n",
     "from sklearn.model_selection import train_test_split\n",
     "import random\n",
@@ -35,29 +14,50 @@
     "import pandas as pd\n",
     "import lightgbm as lgb\n",
     "from sklearn.metrics import accuracy_score, f1_score\n",
-    "import os\n",
-    "os.chdir(\"..\")\n",
+    "\n",
     "%load_ext autoreload\n",
     "%autoreload 2"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "# Utility Functions"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
+    "\n",
+    "def make_mixed_classification(n_samples, n_features, n_categories):\n",
+    "    X,y = make_classification(n_samples=n_samples, n_features=n_features, random_state=42, n_informative=5)\n",
+    "    cat_cols = random.choices(list(range(X.shape[-1])),k=n_categories)\n",
+    "    num_cols = [i for i in range(X.shape[-1]) if i not in cat_cols]\n",
+    "    for col in cat_cols:\n",
+    "        X[:,col] = pd.qcut(X[:,col], q=4).codes.astype(int)\n",
+    "    col_names = [] \n",
+    "    num_col_names=[]\n",
+    "    cat_col_names=[]\n",
+    "    for i in range(X.shape[-1]):\n",
+    "        if i in cat_cols:\n",
+    "            col_names.append(f\"cat_col_{i}\")\n",
+    "            cat_col_names.append(f\"cat_col_{i}\")\n",
+    "        if i in num_cols:\n",
+    "            col_names.append(f\"num_col_{i}\")\n",
+    "            num_col_names.append(f\"num_col_{i}\")\n",
+    "    X = pd.DataFrame(X, columns=col_names)\n",
+    "    y = pd.Series(y, name=\"target\")\n",
+    "    data = X.join(y)\n",
+    "    return data, cat_col_names, num_col_names\n",
+    "    \n",
     "def load_classification_data():\n",
     "    dataset = fetch_covtype(data_home=\"data\")\n",
     "    data = np.hstack([dataset.data, dataset.target.reshape(-1, 1)])\n",
@@ -83,67 +83,50 @@
     "    val_acc = accuracy_score(y_true, y_pred)\n",
     "    val_f1 = f1_score(y_true, y_pred)\n",
     "    print(f\"{tag} Acc: {val_acc} | {tag} F1: {val_f1}\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "# Generate Synthetic Data \n",
     "\n",
     "First of all, let's create a synthetic data which is a mix of numerical and categorical features"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "data, cat_col_names, num_col_names = make_mixed_classification(n_samples=10000, n_features=20, n_categories=4)\n",
     "train, test = train_test_split(data, random_state=42)\n",
     "train, val = train_test_split(train, random_state=42)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "## Baseline\n",
     "\n",
     "Let's use the default LightGBM model as a baseline."
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Acc: 0.9290666666666667 | Validation F1: 0.9285330467490596\n",
-      "Holdout Acc: 0.9344 | Holdout F1: 0.9346613545816733\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\lightgbm\\basic.py:1551: UserWarning: Using categorical_feature in Dataset.\n",
-      "  warnings.warn('Using categorical_feature in Dataset.')\n"
-     ]
-    }
-   ],
    "source": [
     "clf = lgb.LGBMClassifier(random_state=42)\n",
     "clf.fit(train.drop(columns='target'), train['target'], categorical_feature=cat_col_names)\n",
@@ -151,36 +134,55 @@
     "print_metrics(val['target'], val_pred, \"Validation\")\n",
     "test_pred = clf.predict(test.drop(columns='target'))\n",
     "print_metrics(test['target'], test_pred, \"Holdout\")"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/lightgbm/basic.py:1702: UserWarning: Using categorical_feature in Dataset.\n",
+      "  _log_warning('Using categorical_feature in Dataset.')\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Validation Acc: 0.9328 | Validation F1: 0.9322580645161291\n",
+      "Holdout Acc: 0.9328 | Holdout F1: 0.9330677290836654\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "# Importing the Library"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
+   "execution_count": 18,
    "source": [
     "from pytorch_tabular import TabularModel\n",
     "from pytorch_tabular.models import CategoryEmbeddingModelConfig, NodeConfig, TabNetModelConfig\n",
     "from pytorch_tabular.config import DataConfig, OptimizerConfig, TrainerConfig, ExperimentConfig\n",
-    "from pytorch_tabular.category_encoders import CategoricalEmbeddingTransformer"
-   ]
+    "from pytorch_tabular.categorical_encoders import CategoricalEmbeddingTransformer\n",
+    "\n"
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "## Define the Configs\n",
     "\n",
@@ -191,15 +193,14 @@
     "* TrainerConfig - This let's you configure the training process by setting things like batch_size, epochs, early stopping, etc. The vast majority of parameters are directly borrowed from PyTorch Lightning and is passed to the underlying Trainer object during training\n",
     "* OptimizerConfig - This let's you define and use different Optimizers and LearningRate Schedulers. Standard PyTorch Optimizers and Learning RateSchedulers are supported. For custom optimizers, you can use the parameter in the fit method to overwrite this. The custom optimizer should be PyTorch compatible\n",
     "* ExperimentConfig - This is an optional parameter. If set, this defines the Experiment Tracking. Right now, only two experiment tracking frameworks are supported: Tensorboard and Weights&Biases. W&B experiment tracker has more features like tracking the gradients and logits across epochs."
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
+   "execution_count": 11,
    "source": [
     "data_config = DataConfig(\n",
     "    target=['target'], #target should always be a list. Multi-targets are only supported for regression. Multi-Task Classification is not implemented\n",
@@ -212,7 +213,8 @@
     "    auto_lr_find=True, # Runs the LRFinder to automatically derive a learning rate\n",
     "    batch_size=1024,\n",
     "    max_epochs=1000,\n",
-    "    gpus=1, #index of the GPU to use. 0, means CPU\n",
+    "    auto_select_gpus=False,\n",
+    "    gpus=0, #index of the GPU to use. 0, means CPU\n",
     ")\n",
     "optimizer_config = OptimizerConfig()\n",
     "model_config = CategoryEmbeddingModelConfig(\n",
@@ -228,21 +230,68 @@
     "    optimizer_config=optimizer_config,\n",
     "    trainer_config=trainer_config,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "true"
-   },
    "source": [
     "## Training the Model \n",
     "Now that we have defined the configs and the TabularModel. We just need to call the `fit` method and pass the train and test dataframes. We can also pass in validation dataframe. But if omitted, TabularModel will separate 20% of the data as validation."
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "true"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
+   "source": [
+    "tabular_model.fit(train=train, test=test)"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "GPU available: False, used: False\n",
+      "TPU available: False, using: 0 TPU cores\n",
+      "\n",
+      "  | Name                   | Type                | Params\n",
+      "---------------------------------------------------------------\n",
+      "0 | embedding_layers       | ModuleList          | 45    \n",
+      "1 | normalizing_batch_norm | BatchNorm1d         | 34    \n",
+      "2 | backbone               | FeedForwardBackbone | 19.0 M\n",
+      "3 | output_layer           | Linear              | 1.0 K \n",
+      "4 | loss                   | CrossEntropyLoss    | 0     \n",
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: The dataloader, val dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 4 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "  warnings.warn(*args, **kwargs)\n",
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: The dataloader, train dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 4 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "  warnings.warn(*args, **kwargs)\n",
+      "Finding best initial lr:  88%|████████▊ | 88/100 [04:20<00:35,  2.96s/it]\n",
+      "LR finder stopped early due to diverging loss.\n",
+      "Learning rate set to 0.0005248074602497723\n",
+      "\n",
+      "  | Name                   | Type                | Params\n",
+      "---------------------------------------------------------------\n",
+      "0 | embedding_layers       | ModuleList          | 45    \n",
+      "1 | normalizing_batch_norm | BatchNorm1d         | 34    \n",
+      "2 | backbone               | FeedForwardBackbone | 19.0 M\n",
+      "3 | output_layer           | Linear              | 1.0 K \n",
+      "4 | loss                   | CrossEntropyLoss    | 0     \n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Epoch 32: 100%|██████████| 7/7 [00:35<00:00,  7.09s/it, loss=0.552, train_loss=0.59, valid_loss=0.423, valid_accuracy=0.831, train_accuracy=0.698]"
+     ]
+    }
+   ],
    "metadata": {
     "Collapsed": "false",
     "collapsed": true,
@@ -250,254 +299,113 @@
      "outputs_hidden": true
     },
     "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\pytorch_lightning\\utilities\\distributed.py:45: UserWarning: Checkpoint directory saved_models exists and is not empty. With save_top_k=1, all files in this directory will be deleted when a checkpoint is saved!\n",
-      "  warnings.warn(*args, **kwargs)\n",
-      "GPU available: True, used: False\n",
-      "GPU available: True, used: False\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\pytorch_lightning\\utilities\\distributed.py:45: UserWarning: GPU available but not used. Set the --gpus flag when calling the script.\n",
-      "  warnings.warn(*args, **kwargs)\n",
-      "GPU available: True, used: True\n",
-      "GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "\n",
-      "  | Name                   | Type             | Params\n",
-      "------------------------------------------------------------\n",
-      "0 | embedding_layers       | ModuleList       | 60    \n",
-      "1 | normalizing_batch_norm | BatchNorm1d      | 32    \n",
-      "2 | linear_layers          | Sequential       | 19.0 M\n",
-      "3 | loss                   | CrossEntropyLoss | 0     \n",
-      "\n",
-      "  | Name                   | Type             | Params\n",
-      "------------------------------------------------------------\n",
-      "0 | embedding_layers       | ModuleList       | 60    \n",
-      "1 | normalizing_batch_norm | BatchNorm1d      | 32    \n",
-      "2 | linear_layers          | Sequential       | 19.0 M\n",
-      "3 | loss                   | CrossEntropyLoss | 0     \n",
-      "\n",
-      "Finding best initial lr:   0%|                                                                 | 0/100 [00:00<?, ?it/s]\u001b[A\n",
-      "Finding best initial lr:   2%|█▏                                                       | 2/100 [00:00<00:08, 11.52it/s]\u001b[A\n",
-      "Finding best initial lr:   4%|██▎                                                      | 4/100 [00:00<00:08, 11.66it/s]\u001b[A\n",
-      "Finding best initial lr:   6%|███▍                                                     | 6/100 [00:00<00:08, 11.25it/s]\u001b[A\n",
-      "Finding best initial lr:   8%|████▌                                                    | 8/100 [00:00<00:08, 11.25it/s]\u001b[A\n",
-      "Finding best initial lr:  10%|█████▌                                                  | 10/100 [00:00<00:07, 12.50it/s]\u001b[A\n",
-      "Finding best initial lr:  12%|██████▋                                                 | 12/100 [00:01<00:08, 10.55it/s]\u001b[A\n",
-      "Finding best initial lr:  14%|███████▊                                                | 14/100 [00:01<00:07, 10.78it/s]\u001b[A\n",
-      "Finding best initial lr:  16%|████████▉                                               | 16/100 [00:01<00:08,  9.55it/s]\u001b[A\n",
-      "Finding best initial lr:  17%|█████████▌                                              | 17/100 [00:01<00:09,  9.08it/s]\u001b[A\n",
-      "Finding best initial lr:  18%|██████████                                              | 18/100 [00:01<00:09,  8.97it/s]\u001b[A\n",
-      "Finding best initial lr:  20%|███████████▏                                            | 20/100 [00:01<00:07, 10.21it/s]\u001b[A\n",
-      "Finding best initial lr:  22%|████████████▎                                           | 22/100 [00:02<00:09,  8.56it/s]\u001b[A\n",
-      "Finding best initial lr:  23%|████████████▉                                           | 23/100 [00:02<00:09,  8.22it/s]\u001b[A\n",
-      "Finding best initial lr:  25%|██████████████                                          | 25/100 [00:02<00:07,  9.69it/s]\u001b[A\n",
-      "Finding best initial lr:  27%|███████████████                                         | 27/100 [00:02<00:08,  9.12it/s]\u001b[A\n",
-      "Finding best initial lr:  29%|████████████████▏                                       | 29/100 [00:02<00:07,  9.77it/s]\u001b[A\n",
-      "Finding best initial lr:  31%|█████████████████▎                                      | 31/100 [00:03<00:06,  9.95it/s]\u001b[A\n",
-      "Finding best initial lr:  33%|██████████████████▍                                     | 33/100 [00:03<00:06, 10.29it/s]\u001b[A\n",
-      "Finding best initial lr:  35%|███████████████████▌                                    | 35/100 [00:03<00:05, 11.67it/s]\u001b[A\n",
-      "Finding best initial lr:  37%|████████████████████▋                                   | 37/100 [00:03<00:06, 10.19it/s]\u001b[A\n",
-      "Finding best initial lr:  39%|█████████████████████▊                                  | 39/100 [00:03<00:05, 10.59it/s]\u001b[A\n",
-      "Finding best initial lr:  41%|██████████████████████▉                                 | 41/100 [00:04<00:05, 10.48it/s]\u001b[A\n",
-      "Finding best initial lr:  43%|████████████████████████                                | 43/100 [00:04<00:05, 10.71it/s]\u001b[A\n",
-      "Finding best initial lr:  45%|█████████████████████████▏                              | 45/100 [00:04<00:04, 12.02it/s]\u001b[A\n",
-      "Finding best initial lr:  47%|██████████████████████████▎                             | 47/100 [00:04<00:05, 10.52it/s]\u001b[A\n",
-      "Finding best initial lr:  49%|███████████████████████████▍                            | 49/100 [00:04<00:04, 10.89it/s]\u001b[A\n",
-      "Finding best initial lr:  51%|████████████████████████████▌                           | 51/100 [00:04<00:04, 10.69it/s]\u001b[A\n",
-      "Finding best initial lr:  53%|█████████████████████████████▋                          | 53/100 [00:05<00:04, 10.89it/s]\u001b[A\n",
-      "Finding best initial lr:  55%|██████████████████████████████▊                         | 55/100 [00:05<00:03, 12.14it/s]\u001b[A\n",
-      "Finding best initial lr:  57%|███████████████████████████████▉                        | 57/100 [00:05<00:04, 10.64it/s]\u001b[A\n",
-      "Finding best initial lr:  59%|█████████████████████████████████                       | 59/100 [00:05<00:03, 11.05it/s]\u001b[A\n",
-      "Finding best initial lr:  61%|██████████████████████████████████▏                     | 61/100 [00:05<00:03, 10.86it/s]\u001b[A\n",
-      "Finding best initial lr:  63%|███████████████████████████████████▎                    | 63/100 [00:05<00:03, 10.94it/s]\u001b[A\n",
-      "Finding best initial lr:  65%|████████████████████████████████████▍                   | 65/100 [00:06<00:02, 12.23it/s]\u001b[A\n",
-      "Finding best initial lr:  67%|█████████████████████████████████████▌                  | 67/100 [00:06<00:03, 10.58it/s]\u001b[A\n",
-      "Finding best initial lr:  69%|██████████████████████████████████████▋                 | 69/100 [00:06<00:02, 10.97it/s]\u001b[A\n",
-      "Finding best initial lr:  71%|███████████████████████████████████████▊                | 71/100 [00:06<00:02, 10.72it/s]\u001b[A\n",
-      "Finding best initial lr:  73%|████████████████████████████████████████▉               | 73/100 [00:06<00:02, 10.78it/s]\u001b[A\n",
-      "Finding best initial lr:  75%|██████████████████████████████████████████              | 75/100 [00:07<00:02, 12.08it/s]\u001b[A\n",
-      "Finding best initial lr:  77%|███████████████████████████████████████████             | 77/100 [00:07<00:02, 10.39it/s]\u001b[A\n",
-      "Finding best initial lr:  79%|████████████████████████████████████████████▏           | 79/100 [00:07<00:01, 10.83it/s]\u001b[A\n",
-      "Finding best initial lr:  81%|█████████████████████████████████████████████▎          | 81/100 [00:07<00:01, 10.68it/s]\u001b[A\n",
-      "Finding best initial lr:  84%|███████████████████████████████████████████████         | 84/100 [00:07<00:01, 10.64it/s]\u001b[A\n",
-      "LR finder stopped early due to diverging loss.\n",
-      "LR finder stopped early due to diverging loss.\n",
-      "Learning rate set to 0.0003019951720402019\n",
-      "Learning rate set to 0.0003019951720402019\n",
-      "\n",
-      "  | Name                   | Type             | Params\n",
-      "------------------------------------------------------------\n",
-      "0 | embedding_layers       | ModuleList       | 60    \n",
-      "1 | normalizing_batch_norm | BatchNorm1d      | 32    \n",
-      "2 | linear_layers          | Sequential       | 19.0 M\n",
-      "3 | loss                   | CrossEntropyLoss | 0     \n",
-      "\n",
-      "  | Name                   | Type             | Params\n",
-      "------------------------------------------------------------\n",
-      "0 | embedding_layers       | ModuleList       | 60    \n",
-      "1 | normalizing_batch_norm | BatchNorm1d      | 32    \n",
-      "2 | linear_layers          | Sequential       | 19.0 M\n",
-      "3 | loss                   | CrossEntropyLoss | 0     \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1:  71%|▋| 5/7 [00:00<00:00,  4.60it/s, loss=11.006, train_loss=0.728, valid_loss=19.2, valid_accuracy=0.485, tra\n",
-      "Epoch 1: 100%|█| 7/7 [00:03<00:00,  1.15it/s, loss=11.006, train_loss=0.728, valid_loss=0.712, valid_accuracy=0.673, tr\n",
-      "Epoch 2:  71%|▋| 5/7 [00:00<00:00,  4.70it/s, loss=11.017, train_loss=0.65, valid_loss=0.712, valid_accuracy=0.673, tra\n",
-      "Epoch 2: 100%|█| 7/7 [00:03<00:00,  1.04it/s, loss=11.017, train_loss=0.65, valid_loss=0.667, valid_accuracy=0.518, tra\n",
-      "Epoch 3:  71%|▋| 5/7 [00:00<00:00,  4.62it/s, loss=10.940, train_loss=0.644, valid_loss=0.667, valid_accuracy=0.518, tr\n",
-      "Epoch 3: 100%|█| 7/7 [00:04<00:00,  1.10s/it, loss=10.940, train_loss=0.644, valid_loss=0.633, valid_accuracy=0.688, tr\n",
-      "Epoch 4:  71%|▋| 5/7 [00:00<00:00,  4.74it/s, loss=1.421, train_loss=0.6, valid_loss=0.633, valid_accuracy=0.688, train\n",
-      "Epoch 4: 100%|█| 7/7 [00:04<00:00,  1.08s/it, loss=1.421, train_loss=0.6, valid_loss=0.586, valid_accuracy=0.739, train\n",
-      "Epoch 5:  71%|▋| 5/7 [00:00<00:00,  4.58it/s, loss=0.654, train_loss=0.61, valid_loss=0.586, valid_accuracy=0.739, trai\n",
-      "Epoch 5: 100%|█| 7/7 [00:04<00:00,  1.01s/it, loss=0.654, train_loss=0.61, valid_loss=0.558, valid_accuracy=0.734, trai\n",
-      "Epoch 6:  71%|▋| 5/7 [00:00<00:00,  4.63it/s, loss=0.631, train_loss=0.62, valid_loss=0.558, valid_accuracy=0.734, trai\n",
-      "Epoch 6: 100%|█| 7/7 [00:00<00:00,  8.23it/s, loss=0.631, train_loss=0.62, valid_loss=0.568, valid_accuracy=0.736, trai\n",
-      "Epoch 7:  71%|▋| 5/7 [00:00<00:00,  4.87it/s, loss=0.618, train_loss=0.613, valid_loss=0.568, valid_accuracy=0.736, tra\n",
-      "Epoch 7: 100%|█| 7/7 [00:03<00:00,  1.06it/s, loss=0.618, train_loss=0.613, valid_loss=0.547, valid_accuracy=0.743, tra\n",
-      "Epoch 8:  71%|▋| 5/7 [00:00<00:00,  4.74it/s, loss=0.607, train_loss=0.624, valid_loss=0.547, valid_accuracy=0.743, tra\n",
-      "Epoch 14: 100%|█| 7/7 [01:57<00:00, 39.15s/it, loss=0.491, train_loss=0.541, valid_loss=0.329, valid_auroc=0.151, valid\n",
-      "\n",
-      "Epoch 8: 100%|█| 7/7 [00:05<00:00,  1.27s/it, loss=0.607, train_loss=0.624, valid_loss=0.53, valid_accuracy=0.748, trai\u001b[A\n",
-      "Epoch 9:  86%|▊| 6/7 [00:00<00:00,  6.90it/s, loss=0.600, train_loss=0.574, valid_loss=0.53, valid_accuracy=0.748, trai\u001b[A\n",
-      "Epoch 9: 100%|█| 7/7 [00:04<00:00,  1.05s/it, loss=0.600, train_loss=0.574, valid_loss=0.516, valid_accuracy=0.756, tra\n",
-      "Epoch 10:  86%|▊| 6/7 [00:00<00:00,  6.92it/s, loss=0.596, train_loss=0.658, valid_loss=0.516, valid_accuracy=0.756, tr\n",
-      "Epoch 10: 100%|█| 7/7 [00:03<00:00,  1.14it/s, loss=0.596, train_loss=0.658, valid_loss=0.51, valid_accuracy=0.753, tra\n",
-      "Epoch 11:  86%|▊| 6/7 [00:00<00:00,  7.02it/s, loss=0.590, train_loss=0.572, valid_loss=0.51, valid_accuracy=0.753, tra\n",
-      "Epoch 11: 100%|█| 7/7 [00:00<00:00,  8.37it/s, loss=0.590, train_loss=0.572, valid_loss=0.528, valid_accuracy=0.644, tr\n",
-      "Epoch 12:  86%|▊| 6/7 [00:00<00:00,  7.18it/s, loss=0.588, train_loss=0.581, valid_loss=0.528, valid_accuracy=0.644, tr\n",
-      "Epoch 12: 100%|█| 7/7 [00:03<00:00,  1.20it/s, loss=0.588, train_loss=0.581, valid_loss=0.502, valid_accuracy=0.695, tr\n",
-      "Epoch 13:  86%|▊| 6/7 [00:00<00:00,  7.08it/s, loss=0.582, train_loss=0.54, valid_loss=0.502, valid_accuracy=0.695, tra\n",
-      "Epoch 13: 100%|█| 7/7 [00:04<00:00,  1.12s/it, loss=0.582, train_loss=0.54, valid_loss=0.492, valid_accuracy=0.643, tra\n",
-      "Epoch 14:  86%|▊| 6/7 [00:00<00:00,  6.91it/s, loss=0.573, train_loss=0.556, valid_loss=0.492, valid_accuracy=0.643, tr\n",
-      "Epoch 14: 100%|█| 7/7 [00:03<00:00,  1.27it/s, loss=0.573, train_loss=0.556, valid_loss=0.487, valid_accuracy=0.609, tr\n",
-      "Epoch 15:  86%|▊| 6/7 [00:00<00:00,  7.07it/s, loss=0.567, train_loss=0.565, valid_loss=0.487, valid_accuracy=0.609, tr\n",
-      "Epoch 15: 100%|█| 7/7 [00:00<00:00,  8.40it/s, loss=0.567, train_loss=0.565, valid_loss=0.489, valid_accuracy=0.738, tr\n",
-      "Epoch 16:  86%|▊| 6/7 [00:00<00:00,  7.09it/s, loss=0.560, train_loss=0.542, valid_loss=0.489, valid_accuracy=0.738, tr\n",
-      "Epoch 16: 100%|█| 7/7 [00:03<00:00,  1.13it/s, loss=0.560, train_loss=0.542, valid_loss=0.472, valid_accuracy=0.782, tr\n",
-      "Epoch 17:  86%|▊| 6/7 [00:00<00:00,  6.88it/s, loss=0.556, train_loss=0.545, valid_loss=0.472, valid_accuracy=0.782, tr\n",
-      "Epoch 17: 100%|█| 7/7 [00:04<00:00,  1.18s/it, loss=0.556, train_loss=0.545, valid_loss=0.472, valid_accuracy=0.786, tr\n",
-      "Epoch 18:  86%|▊| 6/7 [00:00<00:00,  7.03it/s, loss=0.554, train_loss=0.539, valid_loss=0.472, valid_accuracy=0.786, tr\n",
-      "Epoch 18: 100%|█| 7/7 [00:03<00:00,  1.19it/s, loss=0.554, train_loss=0.539, valid_loss=0.46, valid_accuracy=0.798, tra\n",
-      "Epoch 19:  86%|▊| 6/7 [00:00<00:00,  6.88it/s, loss=0.551, train_loss=0.547, valid_loss=0.46, valid_accuracy=0.798, tra\n",
-      "Epoch 19: 100%|█| 7/7 [00:03<00:00,  1.21it/s, loss=0.551, train_loss=0.547, valid_loss=0.453, valid_accuracy=0.764, tr\n",
-      "Epoch 20:  86%|▊| 6/7 [00:00<00:00,  6.87it/s, loss=0.547, train_loss=0.558, valid_loss=0.453, valid_accuracy=0.764, tr\n",
-      "Epoch 20: 100%|█| 7/7 [00:00<00:00,  8.20it/s, loss=0.547, train_loss=0.558, valid_loss=0.456, valid_accuracy=0.797, tr\n",
-      "Epoch 21:  86%|▊| 6/7 [00:00<00:00,  7.24it/s, loss=0.543, train_loss=0.521, valid_loss=0.456, valid_accuracy=0.797, tr\n",
-      "Epoch 21: 100%|█| 7/7 [00:04<00:00,  1.03s/it, loss=0.543, train_loss=0.521, valid_loss=0.43, valid_accuracy=0.728, tra\n",
-      "Epoch 22:  86%|▊| 6/7 [00:00<00:00,  7.01it/s, loss=0.541, train_loss=0.552, valid_loss=0.43, valid_accuracy=0.728, tra\n",
-      "Epoch 22: 100%|█| 7/7 [00:00<00:00,  8.34it/s, loss=0.541, train_loss=0.552, valid_loss=0.44, valid_accuracy=0.629, tra\n",
-      "Epoch 23:  86%|▊| 6/7 [00:00<00:00,  7.11it/s, loss=0.537, train_loss=0.49, valid_loss=0.44, valid_accuracy=0.629, trai\n",
-      "Epoch 23: 100%|█| 7/7 [00:00<00:00,  8.48it/s, loss=0.537, train_loss=0.49, valid_loss=0.432, valid_accuracy=0.596, tra\n",
-      "Epoch 24:  86%|▊| 6/7 [00:00<00:00,  7.14it/s, loss=0.537, train_loss=0.53, valid_loss=0.432, valid_accuracy=0.596, tra\n",
-      "Epoch 24: 100%|█| 7/7 [00:04<00:00,  1.01s/it, loss=0.537, train_loss=0.53, valid_loss=0.425, valid_accuracy=0.599, tra\n",
-      "Epoch 25:  86%|▊| 6/7 [00:00<00:00,  6.90it/s, loss=0.534, train_loss=0.533, valid_loss=0.425, valid_accuracy=0.599, tr\n",
-      "Epoch 25: 100%|█| 7/7 [00:00<00:00,  8.24it/s, loss=0.534, train_loss=0.533, valid_loss=0.433, valid_accuracy=0.512, tr\n",
-      "Epoch 26:  86%|▊| 6/7 [00:00<00:00,  7.16it/s, loss=0.533, train_loss=0.495, valid_loss=0.433, valid_accuracy=0.512, tr\n",
-      "Epoch 26: 100%|█| 7/7 [00:00<00:00,  8.50it/s, loss=0.533, train_loss=0.495, valid_loss=0.426, valid_accuracy=0.527, tr\n",
-      "Epoch 27:  86%|▊| 6/7 [00:00<00:00,  7.06it/s, loss=0.530, train_loss=0.504, valid_loss=0.426, valid_accuracy=0.527, tr\n",
-      "Epoch 27: 100%|█| 7/7 [00:04<00:00,  1.11s/it, loss=0.530, train_loss=0.504, valid_loss=0.409, valid_accuracy=0.575, tr\n",
-      "Epoch 28:  86%|▊| 6/7 [00:00<00:00,  7.00it/s, loss=0.525, train_loss=0.527, valid_loss=0.409, valid_accuracy=0.575, tr\n",
-      "Epoch 28: 100%|█| 7/7 [00:04<00:00,  1.02s/it, loss=0.525, train_loss=0.527, valid_loss=0.405, valid_accuracy=0.707, tr\n",
-      "Epoch 29:  86%|▊| 6/7 [00:00<00:00,  6.91it/s, loss=0.523, train_loss=0.524, valid_loss=0.405, valid_accuracy=0.707, tr\n",
-      "Epoch 29: 100%|█| 7/7 [00:00<00:00,  8.22it/s, loss=0.523, train_loss=0.524, valid_loss=0.413, valid_accuracy=0.753, tr\n",
-      "Epoch 30:  86%|▊| 6/7 [00:00<00:00,  6.96it/s, loss=0.523, train_loss=0.526, valid_loss=0.413, valid_accuracy=0.753, tr\n",
-      "Epoch 30: 100%|█| 7/7 [00:00<00:00,  8.32it/s, loss=0.523, train_loss=0.526, valid_loss=0.42, valid_accuracy=0.716, tra\n",
-      "Epoch 31:  86%|▊| 6/7 [00:00<00:00,  7.03it/s, loss=0.522, train_loss=0.498, valid_loss=0.42, valid_accuracy=0.716, tra\n",
-      "Epoch 31: 100%|█| 7/7 [00:04<00:00,  1.07s/it, loss=0.522, train_loss=0.498, valid_loss=0.4, valid_accuracy=0.686, trai\n",
-      "Epoch 32:  86%|▊| 6/7 [00:00<00:00,  6.91it/s, loss=0.523, train_loss=0.548, valid_loss=0.4, valid_accuracy=0.686, trai\n",
-      "Epoch 32: 100%|█| 7/7 [00:00<00:00,  8.28it/s, loss=0.523, train_loss=0.548, valid_loss=0.409, valid_accuracy=0.722, tr\n",
-      "Epoch 33:  86%|▊| 6/7 [00:00<00:00,  7.04it/s, loss=0.524, train_loss=0.554, valid_loss=0.409, valid_accuracy=0.722, tr\n",
-      "Epoch 33: 100%|█| 7/7 [00:04<00:00,  1.22s/it, loss=0.524, train_loss=0.554, valid_loss=0.399, valid_accuracy=0.682, tr\n",
-      "Epoch 34:  86%|▊| 6/7 [00:00<00:00,  6.86it/s, loss=0.520, train_loss=0.518, valid_loss=0.399, valid_accuracy=0.682, tr\n",
-      "Epoch 34: 100%|█| 7/7 [00:00<00:00,  8.21it/s, loss=0.520, train_loss=0.518, valid_loss=0.412, valid_accuracy=0.596, tr\n",
-      "Epoch 35:  86%|▊| 6/7 [00:00<00:00,  7.01it/s, loss=0.519, train_loss=0.495, valid_loss=0.412, valid_accuracy=0.596, tr\n",
-      "Epoch 35: 100%|█| 7/7 [00:00<00:00,  8.36it/s, loss=0.519, train_loss=0.495, valid_loss=0.4, valid_accuracy=0.577, trai\n",
-      "Epoch 36:  86%|▊| 6/7 [00:00<00:00,  7.01it/s, loss=0.515, train_loss=0.516, valid_loss=0.4, valid_accuracy=0.577, trai\n",
-      "Epoch 36: 100%|█| 7/7 [00:04<00:00,  1.11s/it, loss=0.515, train_loss=0.516, valid_loss=0.389, valid_accuracy=0.585, tr\n",
-      "Epoch 37:  86%|▊| 6/7 [00:00<00:00,  6.84it/s, loss=0.509, train_loss=0.486, valid_loss=0.389, valid_accuracy=0.585, tr\n",
-      "Epoch 37: 100%|█| 7/7 [00:00<00:00,  8.09it/s, loss=0.509, train_loss=0.486, valid_loss=0.399, valid_accuracy=0.617, tr\n",
-      "Epoch 38:  86%|▊| 6/7 [00:00<00:00,  7.21it/s, loss=0.507, train_loss=0.491, valid_loss=0.399, valid_accuracy=0.617, tr\n",
-      "Epoch 38: 100%|█| 7/7 [00:00<00:00,  8.57it/s, loss=0.507, train_loss=0.491, valid_loss=0.398, valid_accuracy=0.614, tr\n",
-      "Epoch 39:  86%|▊| 6/7 [00:00<00:00,  7.08it/s, loss=0.509, train_loss=0.582, valid_loss=0.398, valid_accuracy=0.614, tr\n",
-      "Epoch 39: 100%|█| 7/7 [00:00<00:00,  8.44it/s, loss=0.509, train_loss=0.582, valid_loss=0.4, valid_accuracy=0.524, trai\n",
-      "Epoch 39: 100%|█| 7/7 [00:11<00:00,  2.89s/it, loss=0.509, train_loss=0.582, valid_loss=0.4, valid_accuracy=0.524, trai"
-     ]
-    }
-   ],
-   "source": [
-    "tabular_model.fit(train=train, test=test)"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "## Evaluating the Model\n",
     "To evaluate the model on new data on the same metrics/loss that was used during training, we can use the `evaluate` method"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Testing: 100%|███████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 25.28it/s]--------------------------------------------------------------------------------\n",
-      "DATALOADER:0 TEST RESULTS\n",
-      "{'test_accuracy': tensor(0.5808, device='cuda:0'),\n",
-      " 'train_accuracy': tensor(0.5936, device='cuda:0'),\n",
-      " 'train_loss': tensor(0.5825, device='cuda:0'),\n",
-      " 'valid_accuracy': tensor(0.5244, device='cuda:0'),\n",
-      " 'valid_loss': tensor(0.4004, device='cuda:0')}\n",
-      "--------------------------------------------------------------------------------\n",
-      "Testing: 100%|███████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 21.18it/s]\n",
-      "[{'train_loss': 0.582484245300293, 'valid_loss': 0.40044283866882324, 'valid_accuracy': 0.5244444608688354, 'train_accuracy': 0.5935624241828918, 'test_accuracy': 0.5807999968528748}]\n"
-     ]
-    }
-   ],
+   "execution_count": 13,
    "source": [
     "result = tabular_model.evaluate(test)\n",
     "print(result)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: The dataloader, test dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 4 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "  warnings.warn(*args, **kwargs)\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Testing: 100%|██████████| 3/3 [00:15<00:00,  4.14s/it]--------------------------------------------------------------------------------\n",
+      "DATALOADER:0 TEST RESULTS\n",
+      "{'test_accuracy': tensor(0.8416),\n",
+      " 'train_accuracy': tensor(0.7048),\n",
+      " 'train_loss': tensor(0.5903),\n",
+      " 'valid_accuracy': tensor(0.8311),\n",
+      " 'valid_loss': tensor(0.4232)}\n",
+      "--------------------------------------------------------------------------------\n",
+      "Testing: 100%|██████████| 3/3 [00:15<00:00,  5.22s/it]\n",
+      "[{'train_loss': 0.5903493762016296, 'valid_loss': 0.4231547713279724, 'valid_accuracy': 0.8311111330986023, 'train_accuracy': 0.7048248052597046, 'test_accuracy': 0.8416000008583069}]\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "To get the prediction as a dataframe, we can use the `predict` method. This will add predictions to the same dataframe that was passed in. For classification problems, we get both the probabilities and the final prediction taking 0.5 as the threshold"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "execution_count": 14,
+   "source": [
+    "pred_df = tabular_model.predict(test)\n",
+    "pred_df.head()"
+   ],
    "outputs": [
     {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Generating Predictions...: 100%|██████████| 3/3 [00:14<00:00,  4.92s/it]\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "      num_col_0  cat_col_1  num_col_2  num_col_3  num_col_4  num_col_5  \\\n",
+       "6252  -2.790932        0.0  -2.010758   3.205420  -0.356361  -0.744417   \n",
+       "4684  -0.139585        0.0  -1.207160   2.690514   1.072764  -3.499028   \n",
+       "1731   0.001421        1.0  -0.279572   0.363639   0.852329   0.089246   \n",
+       "4742   0.086662        3.0   0.798527   0.916448  -1.085978   0.512223   \n",
+       "4521   0.982186        2.0  -0.117476  -0.168583  -0.088413  -0.206658   \n",
+       "\n",
+       "      num_col_6  num_col_7  cat_col_8  num_col_9  ...  num_col_14  num_col_15  \\\n",
+       "6252   0.427836  -1.492040        0.0   1.364186  ...   -0.660336   -0.705788   \n",
+       "4684   1.561682   0.953991        2.0   1.243788  ...   -2.726836    0.944248   \n",
+       "1731   0.084824   0.194984        0.0   2.668561  ...   -0.508633    0.508788   \n",
+       "4742  -0.903704   1.538725        2.0   1.518521  ...    0.326685    1.343219   \n",
+       "4521  -1.233511  -0.137569        3.0  -1.678887  ...   -0.282845    0.458761   \n",
+       "\n",
+       "      num_col_16  num_col_17  num_col_18  num_col_19  target  0_probability  \\\n",
+       "6252    0.229519    0.060878   -0.464394    2.879481       0       0.145202   \n",
+       "4684    0.821184    0.368647   -1.199147    0.126323       1       0.517947   \n",
+       "1731   -0.097083   -0.128070   -0.282642   -0.190155       0       0.830036   \n",
+       "4742   -1.147619    1.795053    0.857619    0.532915       1       0.469329   \n",
+       "4521    1.381926   -0.566849   -0.475947   -0.400418       1       0.269307   \n",
+       "\n",
+       "      1_probability  prediction  \n",
+       "6252       0.854798           1  \n",
+       "4684       0.482053           0  \n",
+       "1731       0.169964           0  \n",
+       "4742       0.530671           1  \n",
+       "4521       0.730693           1  \n",
+       "\n",
+       "[5 rows x 24 columns]"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -518,15 +426,15 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>num_col_0</th>\n",
-       "      <th>num_col_1</th>\n",
+       "      <th>cat_col_1</th>\n",
        "      <th>num_col_2</th>\n",
        "      <th>num_col_3</th>\n",
        "      <th>num_col_4</th>\n",
-       "      <th>cat_col_5</th>\n",
-       "      <th>cat_col_6</th>\n",
-       "      <th>cat_col_7</th>\n",
-       "      <th>num_col_8</th>\n",
-       "      <th>cat_col_9</th>\n",
+       "      <th>num_col_5</th>\n",
+       "      <th>num_col_6</th>\n",
+       "      <th>num_col_7</th>\n",
+       "      <th>cat_col_8</th>\n",
+       "      <th>num_col_9</th>\n",
        "      <th>...</th>\n",
        "      <th>num_col_14</th>\n",
        "      <th>num_col_15</th>\n",
@@ -544,15 +452,15 @@
        "    <tr>\n",
        "      <th>6252</th>\n",
        "      <td>-2.790932</td>\n",
-       "      <td>-3.304646</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>-2.010758</td>\n",
        "      <td>3.205420</td>\n",
        "      <td>-0.356361</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>-0.744417</td>\n",
+       "      <td>0.427836</td>\n",
+       "      <td>-1.492040</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>-1.061102</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.364186</td>\n",
        "      <td>...</td>\n",
        "      <td>-0.660336</td>\n",
        "      <td>-0.705788</td>\n",
@@ -561,22 +469,22 @@
        "      <td>-0.464394</td>\n",
        "      <td>2.879481</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.294159</td>\n",
-       "      <td>0.705841</td>\n",
+       "      <td>0.145202</td>\n",
+       "      <td>0.854798</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4684</th>\n",
        "      <td>-0.139585</td>\n",
-       "      <td>-1.360640</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>-1.207160</td>\n",
        "      <td>2.690514</td>\n",
        "      <td>1.072764</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>0.439317</td>\n",
+       "      <td>-3.499028</td>\n",
+       "      <td>1.561682</td>\n",
+       "      <td>0.953991</td>\n",
        "      <td>2.0</td>\n",
+       "      <td>1.243788</td>\n",
        "      <td>...</td>\n",
        "      <td>-2.726836</td>\n",
        "      <td>0.944248</td>\n",
@@ -585,22 +493,22 @@
        "      <td>-1.199147</td>\n",
        "      <td>0.126323</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.642122</td>\n",
-       "      <td>0.357878</td>\n",
+       "      <td>0.517947</td>\n",
+       "      <td>0.482053</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1731</th>\n",
        "      <td>0.001421</td>\n",
-       "      <td>-0.046718</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>-0.279572</td>\n",
        "      <td>0.363639</td>\n",
        "      <td>0.852329</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>-1.005871</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>0.089246</td>\n",
+       "      <td>0.084824</td>\n",
+       "      <td>0.194984</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.668561</td>\n",
        "      <td>...</td>\n",
        "      <td>-0.508633</td>\n",
        "      <td>0.508788</td>\n",
@@ -609,22 +517,22 @@
        "      <td>-0.282642</td>\n",
        "      <td>-0.190155</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.917402</td>\n",
-       "      <td>0.082598</td>\n",
+       "      <td>0.830036</td>\n",
+       "      <td>0.169964</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4742</th>\n",
        "      <td>0.086662</td>\n",
-       "      <td>1.549718</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>0.798527</td>\n",
        "      <td>0.916448</td>\n",
        "      <td>-1.085978</td>\n",
+       "      <td>0.512223</td>\n",
+       "      <td>-0.903704</td>\n",
+       "      <td>1.538725</td>\n",
        "      <td>2.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>0.475361</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.518521</td>\n",
        "      <td>...</td>\n",
        "      <td>0.326685</td>\n",
        "      <td>1.343219</td>\n",
@@ -633,22 +541,22 @@
        "      <td>0.857619</td>\n",
        "      <td>0.532915</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.179932</td>\n",
-       "      <td>0.820068</td>\n",
+       "      <td>0.469329</td>\n",
+       "      <td>0.530671</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4521</th>\n",
        "      <td>0.982186</td>\n",
-       "      <td>0.909692</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>-0.117476</td>\n",
        "      <td>-0.168583</td>\n",
        "      <td>-0.088413</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.253686</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>-0.206658</td>\n",
+       "      <td>-1.233511</td>\n",
+       "      <td>-0.137569</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>-1.678887</td>\n",
        "      <td>...</td>\n",
        "      <td>-0.282845</td>\n",
        "      <td>0.458761</td>\n",
@@ -657,128 +565,89 @@
        "      <td>-0.475947</td>\n",
        "      <td>-0.400418</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.358011</td>\n",
-       "      <td>0.641989</td>\n",
+       "      <td>0.269307</td>\n",
+       "      <td>0.730693</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "<p>5 rows × 24 columns</p>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "      num_col_0  num_col_1  num_col_2  num_col_3  num_col_4  cat_col_5  \\\n",
-       "6252  -2.790932  -3.304646  -2.010758   3.205420  -0.356361        1.0   \n",
-       "4684  -0.139585  -1.360640  -1.207160   2.690514   1.072764        0.0   \n",
-       "1731   0.001421  -0.046718  -0.279572   0.363639   0.852329        2.0   \n",
-       "4742   0.086662   1.549718   0.798527   0.916448  -1.085978        2.0   \n",
-       "4521   0.982186   0.909692  -0.117476  -0.168583  -0.088413        2.0   \n",
-       "\n",
-       "      cat_col_6  cat_col_7  num_col_8  cat_col_9  ...  num_col_14  num_col_15  \\\n",
-       "6252        2.0        0.0  -1.061102        2.0  ...   -0.660336   -0.705788   \n",
-       "4684        3.0        3.0   0.439317        2.0  ...   -2.726836    0.944248   \n",
-       "1731        2.0        2.0  -1.005871        3.0  ...   -0.508633    0.508788   \n",
-       "4742        0.0        3.0   0.475361        2.0  ...    0.326685    1.343219   \n",
-       "4521        0.0        1.0   1.253686        0.0  ...   -0.282845    0.458761   \n",
-       "\n",
-       "      num_col_16  num_col_17  num_col_18  num_col_19  target  0_probability  \\\n",
-       "6252    0.229519    0.060878   -0.464394    2.879481       0       0.294159   \n",
-       "4684    0.821184    0.368647   -1.199147    0.126323       1       0.642122   \n",
-       "1731   -0.097083   -0.128070   -0.282642   -0.190155       0       0.917402   \n",
-       "4742   -1.147619    1.795053    0.857619    0.532915       1       0.179932   \n",
-       "4521    1.381926   -0.566849   -0.475947   -0.400418       1       0.358011   \n",
-       "\n",
-       "      1_probability  prediction  \n",
-       "6252       0.705841           1  \n",
-       "4684       0.357878           0  \n",
-       "1731       0.082598           0  \n",
-       "4742       0.820068           1  \n",
-       "4521       0.641989           1  \n",
-       "\n",
-       "[5 rows x 24 columns]"
       ]
      },
-     "execution_count": 17,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 14
     }
    ],
-   "source": [
-    "pred_df = tabular_model.predict(test)\n",
-    "pred_df.head()"
-   ]
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "execution_count": 15,
+   "source": [
+    "print_metrics(test['target'], pred_df[\"prediction\"], tag=\"Holdout\")"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Holdout Acc: 0.7368 | Holdout F1: 0.7524454477050414\n"
+      "Holdout Acc: 0.8416 | Holdout F1: 0.8558951965065502\n"
      ]
     }
    ],
-   "source": [
-    "print_metrics(test['target'], pred_df[\"prediction\"], tag=\"Holdout\")"
-   ]
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "## Extract the Learned Embedding\n",
     "\n",
     "For the models that support (CategoryEmbeddingModel and CategoryEmbeddingNODE), we can extract the learned embeddings into a sci-kit learn style Transformer."
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "LGBMClassifier(random_state=42)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "transformer = CategoricalEmbeddingTransformer(tabular_model)\n",
     "transf_train = transformer.fit_transform(train)\n",
     "clf = lgb.LGBMClassifier(random_state=42)\n",
     "clf.fit(transf_train.drop(columns='target'), transf_train['target'])"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Encoding the data...: 100%|██████████| 3/3 [00:00<00:00, 32.60it/s]\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "LGBMClassifier(random_state=42)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 19
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Acc: 0.9328 | Validation F1: 0.9313725490196078\n",
-      "Holdout Acc: 0.928 | Holdout F1: 0.9280575539568346\n"
-     ]
-    }
-   ],
    "source": [
     "transf_val = transformer.transform(val)\n",
     "val_pred = clf.predict(transf_val.drop(columns='target'))\n",
@@ -786,63 +655,96 @@
     "transf_test = transformer.transform(test)\n",
     "test_pred = clf.predict(transf_test.drop(columns='target'))\n",
     "print_metrics(transf_test['target'], test_pred, \"Holdout\")"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Encoding the data...: 100%|██████████| 3/3 [00:00<00:00, 56.56it/s]\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Validation Acc: 0.9264 | Validation F1: 0.925646551724138\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Encoding the data...: 100%|██████████| 3/3 [00:00<00:00, 49.19it/s]\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Holdout Acc: 0.934 | Holdout F1: 0.934445768772348\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "## NODE"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   ],
    "metadata": {
     "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[1;31mInit signature:\u001b[0m\n",
-       "\u001b[0mOptimizerConfig\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m\n",
-       "\u001b[0m    \u001b[0moptimizer\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mstr\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;34m'Adam'\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\n",
-       "\u001b[0m    \u001b[0moptimizer_params\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mdict\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m<\u001b[0m\u001b[0mfactory\u001b[0m\u001b[1;33m>\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\n",
-       "\u001b[0m    \u001b[0mlr_scheduler\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mUnion\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mNoneType\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\n",
-       "\u001b[0m    \u001b[0mlr_scheduler_params\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mUnion\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mdict\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mNoneType\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m<\u001b[0m\u001b[0mfactory\u001b[0m\u001b[1;33m>\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\n",
-       "\u001b[0m    \u001b[0mlr_scheduler_monitor_metric\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mUnion\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mNoneType\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;34m'val_loss'\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\n",
-       "\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m->\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-       "\u001b[1;31mDocstring:\u001b[0m     \n",
-       "Optimizer and Learning Rate Scheduler configuration.\n",
-       "Args:\n",
-       "    optimizer (str): The name of the optimizer from torch.optim.\n",
-       "    optimizer_params (dict): The parameters for the optimizer. If left blank, will use default parameters.\n",
-       "    lr_scheduler (Union[str, NoneType]): The name of the LearningRateScheduler to use, if any, from torch.optim.lr_scheduler. If None, will not use any scheduler\n",
-       "    lr_scheduler_params (Union[dict, NoneType]): The parameters for the LearningRateScheduler. If left blank, will use default parameters.\n",
-       "    lr_scheduler_monitor_metric (Union[str, NoneType]): Used with ReduceLROnPlateau, where the plateau is decided based on this metric\n",
-       "\u001b[1;31mFile:\u001b[0m           d:\\playground\\tabular\\pytorch-tabular\\pytorch_tabular\\config\\config.py\n",
-       "\u001b[1;31mType:\u001b[0m           type\n",
-       "\u001b[1;31mSubclasses:\u001b[0m     \n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "OptimizerConfig?"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 21,
+   "source": [
+    "OptimizerConfig?"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\u001b[0;31mInit signature:\u001b[0m\n",
+      "\u001b[0mOptimizerConfig\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0moptimizer\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'Adam'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0moptimizer_params\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mdict\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m<\u001b[0m\u001b[0mfactory\u001b[0m\u001b[0;34m>\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mlr_scheduler\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mlr_scheduler_params\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mdict\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m<\u001b[0m\u001b[0mfactory\u001b[0m\u001b[0;34m>\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mlr_scheduler_monitor_metric\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'valid_loss'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mDocstring:\u001b[0m     \n",
+      "Optimizer and Learning Rate Scheduler configuration.\n",
+      "Args:\n",
+      "    optimizer (str): Any of the standard optimizers from \n",
+      "        [torch.optim](https://pytorch.org/docs/stable/optim.html#algorithms). Defaults to `Adam`\"\n",
+      "\n",
+      "    optimizer_params (dict): The parameters for the optimizer. If left blank, will use default parameters.\n",
+      "\n",
+      "    lr_scheduler (Optional[str, NoneType]): The name of the LearningRateScheduler to use, if any, from [torch.optim.lr_scheduler](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate). \n",
+      "        If None, will not use any scheduler. Defaults to `None`\n",
+      "\n",
+      "    lr_scheduler_params (Optional[dict, NoneType]): The parameters for the LearningRateScheduler. If left blank, will use default parameters.\n",
+      "\n",
+      "    lr_scheduler_monitor_metric (Optional[str, NoneType]): Used with `ReduceLROnPlateau`, where the plateau is decided based on this metric\n",
+      "\u001b[0;31mFile:\u001b[0m           ~/GitHub/pytorch_tabular/pytorch_tabular/config/config.py\n",
+      "\u001b[0;31mType:\u001b[0m           type\n",
+      "\u001b[0;31mSubclasses:\u001b[0m     \n"
+     ]
+    }
+   ],
    "metadata": {
     "Collapsed": "false"
-   },
-   "outputs": [],
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
    "source": [
     "data_config = DataConfig(\n",
     "    target=['target'],\n",
@@ -853,14 +755,15 @@
     ")\n",
     "trainer_config = TrainerConfig(\n",
     "    auto_lr_find=True,\n",
-    "    batch_size=64,\n",
-    "    max_epochs=1000,\n",
-    "    gpus=1,\n",
+    "    batch_size=128,\n",
+    "    max_epochs=100,\n",
+    "    auto_select_gpus=False,\n",
+    "    gpus=0,\n",
     "    # track_grad_norm=2,\n",
     "    gradient_clip_val=10,\n",
     ")\n",
     "# experiment_config = ExperimentConfig(project_name=\"Tabular_test\", log_logits=True)\n",
-    "optimizer_config = OptimizerConfig(lr_scheduler=OneCycleLR, lr_scheduler_params={\"max_lr\":0.3})\n",
+    "optimizer_config = OptimizerConfig()\n",
     "\n",
     "model_config = NodeConfig(\n",
     "    task=\"classification\",\n",
@@ -877,343 +780,153 @@
     "    optimizer_config=optimizer_config,\n",
     "    trainer_config=trainer_config,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "Collapsed": "false",
-    "tags": [
-     "outputPrepend"
-    ]
-   },
+   "execution_count": 30,
+   "source": [
+    "tabular_model.fit(train=train, test=test)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
-      "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\category_encoders\\utils.py:21: FutureWarning: is_categorical is deprecated and will be removed in a future version.  Use is_categorical_dtype instead\n",
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/category_encoders/utils.py:21: FutureWarning: is_categorical is deprecated and will be removed in a future version.  Use is_categorical_dtype instead\n",
       "  elif pd.api.types.is_categorical(cols):\n",
-      "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\pytorch_lightning\\utilities\\distributed.py:45: UserWarning: Checkpoint directory saved_models exists and is not empty. With save_top_k=1, all files in this directory will be deleted when a checkpoint is saved!\n",
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: Checkpoint directory saved_models exists and is not empty. With save_top_k=1, all files in this directory will be deleted when a checkpoint is saved!\n",
       "  warnings.warn(*args, **kwargs)\n",
-      "GPU available: True, used: False\n",
-      "GPU available: True, used: False\n",
+      "GPU available: False, used: False\n",
       "TPU available: False, using: 0 TPU cores\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\pytorch_lightning\\utilities\\distributed.py:45: UserWarning: GPU available but not used. Set the --gpus flag when calling the script.\n",
+      "\n",
+      "  | Name            | Type             | Params\n",
+      "-----------------------------------------------------\n",
+      "0 | backbone        | NODEBackbone     | 32.4 M\n",
+      "1 | output_response | Lambda           | 0     \n",
+      "2 | loss            | CrossEntropyLoss | 0     \n",
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: The dataloader, val dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 4 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
       "  warnings.warn(*args, **kwargs)\n",
-      "GPU available: True, used: True\n",
-      "GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: The dataloader, train dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 4 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "  warnings.warn(*args, **kwargs)\n",
+      "Finding best initial lr: 100%|██████████| 100/100 [56:45<00:00, 25.49s/it]Learning rate set to 0.2754228703338169\n",
       "\n",
       "  | Name            | Type             | Params\n",
       "-----------------------------------------------------\n",
-      "0 | dense_block     | DenseODSTBlock   | 13.1 M\n",
-      "1 | output_response | Lambda           | 0     \n",
-      "2 | loss            | CrossEntropyLoss | 0     \n",
-      "\n",
-      "  | Name            | Type             | Params\n",
-      "-----------------------------------------------------\n",
-      "0 | dense_block     | DenseODSTBlock   | 13.1 M\n",
-      "1 | output_response | Lambda           | 0     \n",
-      "2 | loss            | CrossEntropyLoss | 0     \n",
-      "\n",
-      "Finding best initial lr:   0%|                                                                 | 0/100 [00:00<?, ?it/s]\u001b[A\n",
-      "Finding best initial lr:   1%|▌                                                        | 1/100 [00:00<00:41,  2.40it/s]\u001b[A\n",
-      "Finding best initial lr:   2%|█▏                                                       | 2/100 [00:00<00:34,  2.86it/s]\u001b[A\n",
-      "Finding best initial lr:   3%|█▋                                                       | 3/100 [00:00<00:29,  3.31it/s]\u001b[A\n",
-      "Finding best initial lr:   4%|██▎                                                      | 4/100 [00:00<00:25,  3.74it/s]\u001b[A\n",
-      "Finding best initial lr:   5%|██▊                                                      | 5/100 [00:01<00:23,  4.11it/s]\u001b[A\n",
-      "Finding best initial lr:   6%|███▍                                                     | 6/100 [00:01<00:21,  4.41it/s]\u001b[A\n",
-      "Finding best initial lr:   7%|███▉                                                     | 7/100 [00:01<00:19,  4.66it/s]\u001b[A\n",
-      "Finding best initial lr:   8%|████▌                                                    | 8/100 [00:01<00:19,  4.84it/s]\u001b[A\n",
-      "Finding best initial lr:   9%|█████▏                                                   | 9/100 [00:01<00:18,  4.96it/s]\u001b[A\n",
-      "Finding best initial lr:  10%|█████▌                                                  | 10/100 [00:02<00:17,  5.06it/s]\u001b[A\n",
-      "Finding best initial lr:  11%|██████▏                                                 | 11/100 [00:02<00:17,  5.14it/s]\u001b[A\n",
-      "Finding best initial lr:  12%|██████▋                                                 | 12/100 [00:02<00:17,  5.17it/s]\u001b[A\n",
-      "Finding best initial lr:  13%|███████▎                                                | 13/100 [00:02<00:16,  5.22it/s]\u001b[A\n",
-      "Finding best initial lr:  14%|███████▊                                                | 14/100 [00:02<00:16,  5.25it/s]\u001b[A\n",
-      "Finding best initial lr:  15%|████████▍                                               | 15/100 [00:03<00:16,  5.28it/s]\u001b[A\n",
-      "Finding best initial lr:  16%|████████▉                                               | 16/100 [00:03<00:15,  5.29it/s]\u001b[A\n",
-      "Finding best initial lr:  17%|█████████▌                                              | 17/100 [00:03<00:15,  5.29it/s]\u001b[A\n",
-      "Finding best initial lr:  18%|██████████                                              | 18/100 [00:03<00:15,  5.29it/s]\u001b[A\n",
-      "Finding best initial lr:  19%|██████████▋                                             | 19/100 [00:03<00:15,  5.29it/s]\u001b[A\n",
-      "Finding best initial lr:  20%|███████████▏                                            | 20/100 [00:03<00:15,  5.30it/s]\u001b[A\n",
-      "Finding best initial lr:  21%|███████████▊                                            | 21/100 [00:04<00:14,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  22%|████████████▎                                           | 22/100 [00:04<00:14,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  23%|████████████▉                                           | 23/100 [00:04<00:14,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  24%|█████████████▍                                          | 24/100 [00:04<00:14,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  25%|██████████████                                          | 25/100 [00:04<00:14,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  26%|██████████████▌                                         | 26/100 [00:05<00:13,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  27%|███████████████                                         | 27/100 [00:05<00:13,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  28%|███████████████▋                                        | 28/100 [00:05<00:13,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  29%|████████████████▏                                       | 29/100 [00:05<00:13,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  30%|████████████████▊                                       | 30/100 [00:05<00:13,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  31%|█████████████████▎                                      | 31/100 [00:06<00:13,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  32%|█████████████████▉                                      | 32/100 [00:06<00:12,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  33%|██████████████████▍                                     | 33/100 [00:06<00:12,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  34%|███████████████████                                     | 34/100 [00:06<00:12,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  35%|███████████████████▌                                    | 35/100 [00:06<00:12,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  36%|████████████████████▏                                   | 36/100 [00:07<00:12,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  37%|████████████████████▋                                   | 37/100 [00:07<00:11,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  38%|█████████████████████▎                                  | 38/100 [00:07<00:11,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  39%|█████████████████████▊                                  | 39/100 [00:07<00:11,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  40%|██████████████████████▍                                 | 40/100 [00:07<00:11,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  41%|██████████████████████▉                                 | 41/100 [00:07<00:11,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  42%|███████████████████████▌                                | 42/100 [00:08<00:10,  5.30it/s]\u001b[A\n",
-      "Finding best initial lr:  43%|████████████████████████                                | 43/100 [00:08<00:10,  5.31it/s]\u001b[A\n",
-      "Finding best initial lr:  44%|████████████████████████▋                               | 44/100 [00:08<00:10,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  45%|█████████████████████████▏                              | 45/100 [00:08<00:10,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  46%|█████████████████████████▊                              | 46/100 [00:08<00:10,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  47%|██████████████████████████▎                             | 47/100 [00:09<00:09,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  48%|██████████████████████████▉                             | 48/100 [00:09<00:09,  5.34it/s]\u001b[A\n",
-      "Finding best initial lr:  49%|███████████████████████████▍                            | 49/100 [00:09<00:09,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  50%|████████████████████████████                            | 50/100 [00:09<00:09,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  51%|████████████████████████████▌                           | 51/100 [00:09<00:09,  5.32it/s]\u001b[A\n",
-      "Finding best initial lr:  52%|█████████████████████████████                           | 52/100 [00:10<00:09,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  53%|█████████████████████████████▋                          | 53/100 [00:10<00:08,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  54%|██████████████████████████████▏                         | 54/100 [00:10<00:08,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  55%|██████████████████████████████▊                         | 55/100 [00:10<00:08,  5.33it/s]\u001b[A\n",
-      "Finding best initial lr:  56%|███████████████████████████████▎                        | 56/100 [00:10<00:08,  5.14it/s]\u001b[A\n",
-      "Finding best initial lr:  57%|███████████████████████████████▉                        | 57/100 [00:10<00:08,  5.19it/s]\u001b[A\n",
-      "Finding best initial lr:  58%|████████████████████████████████▍                       | 58/100 [00:11<00:08,  5.23it/s]\u001b[A\n",
-      "Finding best initial lr:  59%|█████████████████████████████████                       | 59/100 [00:11<00:07,  5.27it/s]\u001b[A\n",
-      "Finding best initial lr:  60%|█████████████████████████████████▌                      | 60/100 [00:11<00:07,  5.18it/s]\u001b[A\n",
-      "Finding best initial lr:  61%|██████████████████████████████████▏                     | 61/100 [00:11<00:07,  5.12it/s]\u001b[A\n",
-      "Finding best initial lr:  62%|██████████████████████████████████▋                     | 62/100 [00:11<00:07,  5.09it/s]\u001b[A\n",
-      "Finding best initial lr:  63%|███████████████████████████████████▎                    | 63/100 [00:12<00:07,  5.06it/s]\u001b[A\n",
-      "Finding best initial lr:  64%|███████████████████████████████████▊                    | 64/100 [00:12<00:07,  5.02it/s]\u001b[A\n",
-      "Finding best initial lr:  65%|████████████████████████████████████▍                   | 65/100 [00:12<00:07,  5.00it/s]\u001b[A\n",
-      "Finding best initial lr:  66%|████████████████████████████████████▉                   | 66/100 [00:12<00:06,  4.98it/s]\u001b[A\n",
-      "Finding best initial lr:  67%|█████████████████████████████████████▌                  | 67/100 [00:12<00:06,  4.95it/s]\u001b[A\n",
-      "Finding best initial lr:  68%|██████████████████████████████████████                  | 68/100 [00:13<00:06,  4.96it/s]\u001b[A\n",
-      "Finding best initial lr:  69%|██████████████████████████████████████▋                 | 69/100 [00:13<00:06,  4.96it/s]\u001b[A\n",
-      "Finding best initial lr:  70%|███████████████████████████████████████▏                | 70/100 [00:13<00:06,  4.97it/s]\u001b[A\n",
-      "Finding best initial lr:  71%|███████████████████████████████████████▊                | 71/100 [00:13<00:05,  5.23it/s]\u001b[A\n",
-      "Finding best initial lr:  72%|████████████████████████████████████████▎               | 72/100 [00:16<00:26,  1.06it/s]\u001b[A\n",
-      "Finding best initial lr:  73%|████████████████████████████████████████▉               | 73/100 [00:16<00:19,  1.39it/s]\u001b[A\n",
-      "Finding best initial lr:  74%|█████████████████████████████████████████▍              | 74/100 [00:16<00:14,  1.77it/s]\u001b[A\n",
-      "Finding best initial lr:  75%|██████████████████████████████████████████              | 75/100 [00:17<00:11,  2.19it/s]\u001b[A\n",
-      "Finding best initial lr:  76%|██████████████████████████████████████████▌             | 76/100 [00:17<00:09,  2.64it/s]\u001b[A\n",
-      "Finding best initial lr:  77%|███████████████████████████████████████████             | 77/100 [00:17<00:07,  3.07it/s]\u001b[A\n",
-      "Finding best initial lr:  78%|███████████████████████████████████████████▋            | 78/100 [00:17<00:06,  3.47it/s]\u001b[A\n",
-      "Finding best initial lr:  79%|████████████████████████████████████████████▏           | 79/100 [00:17<00:05,  3.82it/s]\u001b[A\n",
-      "Finding best initial lr:  80%|████████████████████████████████████████████▊           | 80/100 [00:18<00:04,  4.04it/s]\u001b[A\n",
-      "Finding best initial lr:  81%|█████████████████████████████████████████████▎          | 81/100 [00:18<00:04,  4.22it/s]\u001b[A\n",
-      "Finding best initial lr:  82%|█████████████████████████████████████████████▉          | 82/100 [00:18<00:04,  4.34it/s]\u001b[A\n",
-      "Finding best initial lr:  83%|██████████████████████████████████████████████▍         | 83/100 [00:18<00:03,  4.44it/s]\u001b[A\n",
-      "Finding best initial lr:  84%|███████████████████████████████████████████████         | 84/100 [00:18<00:03,  4.50it/s]\u001b[A\n",
-      "Finding best initial lr:  85%|███████████████████████████████████████████████▌        | 85/100 [00:19<00:03,  4.55it/s]\u001b[A\n",
-      "Finding best initial lr:  86%|████████████████████████████████████████████████▏       | 86/100 [00:19<00:03,  4.59it/s]\u001b[A\n",
-      "Finding best initial lr:  87%|████████████████████████████████████████████████▋       | 87/100 [00:19<00:02,  4.62it/s]\u001b[A\n",
-      "Finding best initial lr:  88%|█████████████████████████████████████████████████▎      | 88/100 [00:19<00:02,  4.65it/s]\u001b[A\n",
-      "Finding best initial lr:  89%|█████████████████████████████████████████████████▊      | 89/100 [00:19<00:02,  4.65it/s]\u001b[A\n",
-      "Finding best initial lr:  90%|██████████████████████████████████████████████████▍     | 90/100 [00:20<00:02,  4.65it/s]\u001b[A\n",
-      "Finding best initial lr:  91%|██████████████████████████████████████████████████▉     | 91/100 [00:20<00:01,  4.65it/s]\u001b[A\n",
-      "Finding best initial lr:  92%|███████████████████████████████████████████████████▌    | 92/100 [00:20<00:01,  4.66it/s]\u001b[A\n",
-      "Finding best initial lr:  93%|████████████████████████████████████████████████████    | 93/100 [00:20<00:01,  4.67it/s]\u001b[A\n",
-      "Finding best initial lr:  94%|████████████████████████████████████████████████████▋   | 94/100 [00:21<00:01,  4.67it/s]\u001b[A\n",
-      "Finding best initial lr:  95%|█████████████████████████████████████████████████████▏  | 95/100 [00:21<00:01,  4.67it/s]\u001b[A\n",
-      "Finding best initial lr:  96%|█████████████████████████████████████████████████████▊  | 96/100 [00:21<00:00,  4.67it/s]\u001b[A\n",
-      "Finding best initial lr:  97%|██████████████████████████████████████████████████████▎ | 97/100 [00:21<00:00,  4.69it/s]\u001b[A\n",
-      "Finding best initial lr:  98%|██████████████████████████████████████████████████████▉ | 98/100 [00:21<00:00,  4.69it/s]\u001b[A\n",
-      "Finding best initial lr:  99%|███████████████████████████████████████████████████████▍| 99/100 [00:22<00:00,  4.69it/s]\u001b[A\n",
-      "Finding best initial lr: 100%|███████████████████████████████████████████████████████| 100/100 [00:22<00:00,  4.69it/s]\u001b[ALearning rate set to 0.2754228703338169\n",
-      "Learning rate set to 0.2754228703338169\n",
-      "Finding best initial lr: 100%|███████████████████████████████████████████████████████| 100/100 [00:22<00:00,  4.45it/s]\n",
-      "\n",
-      "  | Name            | Type             | Params\n",
-      "-----------------------------------------------------\n",
-      "0 | dense_block     | DenseODSTBlock   | 13.1 M\n",
-      "1 | output_response | Lambda           | 0     \n",
-      "2 | loss            | CrossEntropyLoss | 0     \n",
-      "\n",
-      "  | Name            | Type             | Params\n",
-      "-----------------------------------------------------\n",
-      "0 | dense_block     | DenseODSTBlock   | 13.1 M\n",
+      "0 | backbone        | NODEBackbone     | 32.4 M\n",
       "1 | output_response | Lambda           | 0     \n",
       "2 | loss            | CrossEntropyLoss | 0     \n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Epoch 1:  80%|▊| 71/89 [00:15<00:06,  2.84it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\n",
-      "Validating: 0it [00:00, ?it/s]\u001b[A\n",
-      "Epoch 1:  82%|▊| 73/89 [00:15<00:05,  2.94it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  11%|███████▉                                                               | 2/18 [00:00<00:02,  7.12it/s]\u001b[A\n",
-      "Epoch 1:  84%|▊| 75/89 [00:15<00:04,  3.02it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  22%|███████████████▊                                                       | 4/18 [00:00<00:01,  7.04it/s]\u001b[A\n",
-      "Epoch 1:  87%|▊| 77/89 [00:15<00:03,  3.09it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  33%|███████████████████████▋                                               | 6/18 [00:00<00:01,  7.04it/s]\u001b[A\n",
-      "Epoch 1:  89%|▉| 79/89 [00:16<00:03,  3.16it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  44%|███████████████████████████████▌                                       | 8/18 [00:01<00:01,  7.03it/s]\u001b[A\n",
-      "Epoch 1:  91%|▉| 81/89 [00:16<00:02,  3.22it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  56%|██████████████████████████████████████▉                               | 10/18 [00:01<00:01,  7.00it/s]\u001b[A\n",
-      "Epoch 1:  93%|▉| 83/89 [00:16<00:01,  3.29it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  67%|██████████████████████████████████████████████▋                       | 12/18 [00:01<00:00,  7.00it/s]\u001b[A\n",
-      "Epoch 1:  96%|▉| 85/89 [00:17<00:01,  3.35it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  78%|██████████████████████████████████████████████████████▍               | 14/18 [00:01<00:00,  6.98it/s]\u001b[A\n",
-      "Epoch 1:  98%|▉| 87/89 [00:17<00:00,  3.41it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Validating:  89%|██████████████████████████████████████████████████████████████▏       | 16/18 [00:02<00:00,  6.95it/s]\u001b[A\n",
-      "Epoch 1: 100%|█| 89/89 [00:17<00:00,  3.47it/s, loss=0.709, train_loss=0.7, valid_loss=0.604, valid_accuracy=0.731, tra\u001b[A\n",
-      "Epoch 1: 100%|█| 89/89 [00:19<00:00,  3.12it/s, loss=0.709, train_loss=0.7, valid_loss=0.695, valid_accuracy=0.515, tra\u001b[A\n",
-      "Epoch 2:  81%|▊| 72/89 [00:15<00:06,  2.82it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating: 0it [00:00, ?it/s]\u001b[A\n",
-      "Validating:   6%|███▉                                                                   | 1/18 [00:00<00:02,  6.77it/s]\u001b[A\n",
-      "Epoch 2:  83%|▊| 74/89 [00:15<00:05,  2.89it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  17%|███████████▊                                                           | 3/18 [00:00<00:02,  6.69it/s]\u001b[A\n",
-      "Epoch 2:  85%|▊| 76/89 [00:16<00:04,  2.96it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  28%|███████████████████▋                                                   | 5/18 [00:00<00:01,  6.65it/s]\u001b[A\n",
-      "Epoch 2:  88%|▉| 78/89 [00:16<00:03,  3.03it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  39%|███████████████████████████▌                                           | 7/18 [00:01<00:01,  6.65it/s]\u001b[A\n",
-      "Epoch 2:  90%|▉| 80/89 [00:16<00:02,  3.09it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  50%|███████████████████████████████████▌                                   | 9/18 [00:01<00:01,  6.63it/s]\u001b[A\n",
-      "Epoch 2:  92%|▉| 82/89 [00:17<00:02,  3.15it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  61%|██████████████████████████████████████████▊                           | 11/18 [00:01<00:01,  6.61it/s]\u001b[A\n",
-      "Epoch 2:  94%|▉| 84/89 [00:17<00:01,  3.21it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  72%|██████████████████████████████████████████████████▌                   | 13/18 [00:01<00:00,  6.61it/s]\u001b[A\n",
-      "Epoch 2:  97%|▉| 86/89 [00:17<00:00,  3.27it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  83%|██████████████████████████████████████████████████████████▎           | 15/18 [00:02<00:00,  6.60it/s]\u001b[A\n",
-      "Epoch 2:  99%|▉| 88/89 [00:18<00:00,  3.33it/s, loss=0.700, train_loss=0.689, valid_loss=0.695, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  94%|██████████████████████████████████████████████████████████████████    | 17/18 [00:02<00:00,  6.61it/s]\u001b[A\n",
-      "Epoch 2: 100%|█| 89/89 [00:18<00:00,  3.33it/s, loss=0.700, train_loss=0.689, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Epoch 3:  81%|▊| 72/89 [00:15<00:06,  2.77it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating: 0it [00:00, ?it/s]\u001b[A\n",
-      "Validating:   6%|███▉                                                                   | 1/18 [00:00<00:02,  6.68it/s]\u001b[A\n",
-      "Epoch 3:  83%|▊| 74/89 [00:16<00:05,  2.84it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  17%|███████████▊                                                           | 3/18 [00:00<00:02,  6.63it/s]\u001b[A\n",
-      "Epoch 3:  85%|▊| 76/89 [00:16<00:04,  2.91it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  28%|███████████████████▋                                                   | 5/18 [00:00<00:01,  6.64it/s]\u001b[A\n",
-      "Epoch 3:  88%|▉| 78/89 [00:16<00:03,  2.98it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  39%|███████████████████████████▌                                           | 7/18 [00:01<00:01,  6.62it/s]\u001b[A\n",
-      "Epoch 3:  90%|▉| 80/89 [00:17<00:02,  3.04it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  50%|███████████████████████████████████▌                                   | 9/18 [00:01<00:01,  6.61it/s]\u001b[A\n",
-      "Epoch 3:  92%|▉| 82/89 [00:17<00:02,  3.10it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  61%|██████████████████████████████████████████▊                           | 11/18 [00:01<00:01,  6.61it/s]\u001b[A\n",
-      "Epoch 3:  94%|▉| 84/89 [00:17<00:01,  3.16it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  72%|██████████████████████████████████████████████████▌                   | 13/18 [00:01<00:00,  6.59it/s]\u001b[A\n",
-      "Epoch 3:  97%|▉| 86/89 [00:18<00:00,  3.22it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  83%|██████████████████████████████████████████████████████████▎           | 15/18 [00:02<00:00,  6.59it/s]\u001b[A\n",
-      "Epoch 3:  99%|▉| 88/89 [00:18<00:00,  3.28it/s, loss=0.730, train_loss=0.688, valid_loss=0.711, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  94%|██████████████████████████████████████████████████████████████████    | 17/18 [00:02<00:00,  6.59it/s]\u001b[A\n",
-      "Epoch 3: 100%|█| 89/89 [00:18<00:00,  3.28it/s, loss=0.730, train_loss=0.688, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Epoch 4:  81%|▊| 72/89 [00:15<00:06,  2.77it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating: 0it [00:00, ?it/s]\u001b[A\n",
-      "Validating:   6%|███▉                                                                   | 1/18 [00:00<00:02,  6.68it/s]\u001b[A\n",
-      "Epoch 4:  83%|▊| 74/89 [00:16<00:05,  2.84it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  17%|███████████▊                                                           | 3/18 [00:00<00:02,  6.63it/s]\u001b[A\n",
-      "Epoch 4:  85%|▊| 76/89 [00:16<00:04,  2.91it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  28%|███████████████████▋                                                   | 5/18 [00:00<00:01,  6.60it/s]\u001b[A\n",
-      "Epoch 4:  88%|▉| 78/89 [00:16<00:03,  2.98it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  39%|███████████████████████████▌                                           | 7/18 [00:01<00:01,  6.58it/s]\u001b[A\n",
-      "Epoch 4:  90%|▉| 80/89 [00:17<00:02,  3.04it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  50%|███████████████████████████████████▌                                   | 9/18 [00:01<00:01,  6.58it/s]\u001b[A\n",
-      "Epoch 4:  92%|▉| 82/89 [00:17<00:02,  3.10it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  61%|██████████████████████████████████████████▊                           | 11/18 [00:01<00:01,  6.59it/s]\u001b[A\n",
-      "Epoch 4:  94%|▉| 84/89 [00:17<00:01,  3.16it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  72%|██████████████████████████████████████████████████▌                   | 13/18 [00:01<00:00,  6.58it/s]\u001b[A\n",
-      "Epoch 4:  97%|▉| 86/89 [00:18<00:00,  3.22it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  83%|██████████████████████████████████████████████████████████▎           | 15/18 [00:02<00:00,  6.59it/s]\u001b[A\n",
-      "Epoch 4:  99%|▉| 88/89 [00:18<00:00,  3.27it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "Validating:  94%|██████████████████████████████████████████████████████████████████    | 17/18 [00:02<00:00,  6.59it/s]\u001b[A\n",
-      "Epoch 4: 100%|█| 89/89 [00:18<00:00,  3.28it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t\u001b[A\n",
-      "                                                                                                                       \u001b[A"
+      "Epoch 19: 100%|██████████| 45/45 [18:35<00:00, 61.95s/it, loss=0.394, train_loss=0.232, valid_loss=0.448, valid_accuracy=0.795, valid_f1=0.795, train_accuracy=0.818, train_f1=0.818]"
      ]
     }
    ],
-   "source": [
-    "tabular_model.fit(train=train, test=test)"
-   ]
+   "metadata": {
+    "Collapsed": "false",
+    "tags": [
+     "outputPrepend"
+    ]
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Testing: 100%|█████████████████████████████████████████████████████████████████████████| 40/40 [00:06<00:00,  6.80it/s]--------------------------------------------------------------------------------\n",
-      "DATALOADER:0 TEST RESULTS\n",
-      "{'test_accuracy': tensor(0.4988, device='cuda:0'),\n",
-      " 'train_accuracy': tensor(0.4843, device='cuda:0'),\n",
-      " 'train_loss': tensor(0.7952, device='cuda:0'),\n",
-      " 'valid_accuracy': tensor(0.5147, device='cuda:0'),\n",
-      " 'valid_loss': tensor(0.6980, device='cuda:0')}\n",
-      "--------------------------------------------------------------------------------\n",
-      "Testing: 100%|█████████████████████████████████████████████████████████████████████████| 40/40 [00:06<00:00,  6.63it/s]\n",
-      "[{'train_loss': 0.7952374219894409, 'valid_loss': 0.6979830861091614, 'valid_accuracy': 0.5146666765213013, 'train_accuracy': 0.48428699374198914, 'test_accuracy': 0.49880000948905945}]\n"
-     ]
-    }
-   ],
+   "execution_count": 31,
    "source": [
     "result = tabular_model.evaluate(test)\n",
     "print(result)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
-      "Epoch 4: 100%|█| 89/89 [00:30<00:00,  2.03it/s, loss=0.713, train_loss=0.795, valid_loss=0.698, valid_accuracy=0.515, t"
+      "/home/fonnesbeck/anaconda3/envs/pitch_effect/lib/python3.9/site-packages/pytorch_lightning/utilities/distributed.py:45: UserWarning: The dataloader, test dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 4 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "  warnings.warn(*args, **kwargs)\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Testing: 100%|██████████| 20/20 [07:23<00:00, 22.04s/it]--------------------------------------------------------------------------------\n",
+      "DATALOADER:0 TEST RESULTS\n",
+      "{'test_accuracy': tensor(0.8384),\n",
+      " 'test_f1': tensor(0.8384),\n",
+      " 'train_accuracy': tensor(0.8136),\n",
+      " 'train_f1': tensor(0.8136),\n",
+      " 'train_loss': tensor(0.2316),\n",
+      " 'valid_accuracy': tensor(0.7947),\n",
+      " 'valid_f1': tensor(0.7947),\n",
+      " 'valid_loss': tensor(0.4481)}\n",
+      "--------------------------------------------------------------------------------\n",
+      "Testing: 100%|██████████| 20/20 [07:23<00:00, 22.18s/it]\n",
+      "[{'train_loss': 0.231593519449234, 'valid_loss': 0.44811415672302246, 'valid_accuracy': 0.7946666479110718, 'valid_f1': 0.7946666479110718, 'train_accuracy': 0.8135850429534912, 'train_f1': 0.8135850429534912, 'test_accuracy': 0.8384000062942505, 'test_f1': 0.8384000062942505}]\n"
      ]
     }
    ],
+   "metadata": {
+    "Collapsed": "false"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
    "source": [
     "node_pred_df = tabular_model.predict(test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
-      "Holdout Acc: 0.5012 | Holdout F1: 0.667732480682121\n"
+      "Generating Predictions...: 100%|██████████| 20/20 [07:17<00:00, 21.85s/it]\n"
      ]
     }
    ],
+   "metadata": {
+    "Collapsed": "false"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
    "source": [
     "print_metrics(test['target'], node_pred_df[\"prediction\"], tag=\"Holdout\")"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Holdout Acc: 0.8384 | Holdout F1: 0.8382706164931946\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "## NODE (Cat Embed)"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "data_config = DataConfig(\n",
     "    target=['target'], #target should always be a list. Multi-targets are only supported for regression. Multi-Task Classification is not implemented\n",
@@ -1249,21 +962,22 @@
     "    optimizer_config=optimizer_config,\n",
     "    trainer_config=trainer_config,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "Collapsed": "false",
-    "tags": [
-     "outputPrepend"
-    ]
-   },
+   "source": [
+    "tabular_model.fit(train=train, test=test)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "D:\\miniconda3\\envs\\df_encoder\\lib\\site-packages\\pytorch_lightning\\utilities\\distributed.py:45: UserWarning: Checkpoint directory saved_models exists and is not empty. With save_top_k=1, all files in this directory will be deleted when a checkpoint is saved!\n",
       "  warnings.warn(*args, **kwargs)\n",
@@ -1316,8 +1030,8 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Epoch 1:  80%|▊| 71/89 [00:04<00:01, 10.39it/s, loss=0.655, train_loss=0.63, valid_loss=0.69, valid_accuracy=0.485, tra\n",
       "Epoch 1:  84%|▊| 75/89 [00:04<00:01, 11.15it/s, loss=0.655, train_loss=0.63, valid_loss=0.69, valid_accuracy=0.485, tra\n",
@@ -1333,15 +1047,15 @@
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "Finding best initial lr: 100%|███████████████████████████████████████████████████████| 100/100 [00:20<00:00, 17.51it/s]"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Epoch 3:  80%|▊| 71/89 [00:04<00:01, 10.38it/s, loss=0.635, train_loss=0.833, valid_loss=0.668, valid_accuracy=0.588, t\n",
       "Epoch 3:  84%|▊| 75/89 [00:04<00:01, 11.14it/s, loss=0.635, train_loss=0.833, valid_loss=0.668, valid_accuracy=0.588, t\n",
@@ -1363,148 +1077,180 @@
      ]
     }
    ],
-   "source": [
-    "tabular_model.fit(train=train, test=test)"
-   ]
+   "metadata": {
+    "Collapsed": "false",
+    "tags": [
+     "outputPrepend"
+    ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "result = tabular_model.evaluate(test)\n",
     "print(result)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "cat_embed_node_pred_df = tabular_model.predict(test)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "print_metrics(test['target'], cat_embed_node_pred_df[\"prediction\"], tag=\"Holdout\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
    "source": [
     "### Use Category embedding"
-   ]
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "LGBMClassifier(random_state=42)"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "transformer = CategoricalEmbeddingTransformer(tabular_model)\n",
     "transf_train = transformer.fit_transform(train)\n",
     "clf = lgb.LGBMClassifier(random_state=42)\n",
     "clf.fit(transf_train.drop(columns='target'), transf_train['target'])"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "LGBMClassifier(random_state=42)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 25
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Val Acc: 0.9322666666666667 | Val F1: 0.932410856838744\n"
-     ]
-    }
-   ],
    "source": [
     "transf_val = transformer.transform(val)\n",
     "val_pred = clf.predict(transf_val.drop(columns='target'))\n",
     "val_acc = accuracy_score(transf_val['target'].values.ravel(), val_pred)\n",
     "val_f1 = f1_score(transf_val['target'].values.ravel(), val_pred)\n",
     "print(f\"Val Acc: {val_acc} | Val F1: {val_f1}\")"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Val Acc: 0.9322666666666667 | Val F1: 0.932410856838744\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test Acc: 0.9368 | Test F1: 0.9383294301327089\n"
-     ]
-    }
-   ],
    "source": [
     "transf_test = transformer.transform(test)\n",
     "test_pred = clf.predict(transf_test.drop(columns='target'))\n",
     "test_acc = accuracy_score(transf_test['target'].values.ravel(), test_pred)\n",
     "test_f1 = f1_score(transf_test['target'].values.ravel(), test_pred)\n",
     "print(f\"Test Acc: {test_acc} | Test F1: {test_f1}\")"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Test Acc: 0.9368 | Test F1: 0.9383294301327089\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "## TabNet"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "Collapsed": "false",
-    "tags": [
-     "outputPrepend"
-    ]
-   },
+   "source": [
+    "data_config = DataConfig(\n",
+    "    target=['target'],\n",
+    "    continuous_cols=num_col_names,\n",
+    "    categorical_cols=cat_col_names,\n",
+    "    continuous_feature_transform=None,#\"yeo-johnson\",\n",
+    "    normalize_continuous_features=True\n",
+    ")\n",
+    "trainer_config = TrainerConfig(\n",
+    "    auto_lr_find=False,\n",
+    "    batch_size=1024,\n",
+    "    max_epochs=1000,\n",
+    "    gpus=1,\n",
+    "    # track_grad_norm=2,\n",
+    "    gradient_clip_val=10,\n",
+    ")\n",
+    "# experiment_config = ExperimentConfig(project_name=\"Tabular_test\", log_logits=True)\n",
+    "optimizer_config = OptimizerConfig()\n",
+    "\n",
+    "model_config = TabNetModelConfig(\n",
+    "    task=\"classification\",\n",
+    "    n_d=5,\n",
+    "    n_a=5,\n",
+    "    n_steps=2,\n",
+    "    n_independent=2,\n",
+    "    n_shared=2,\n",
+    "    learning_rate=1e-3\n",
+    ")\n",
+    "tabular_model = TabularModel(\n",
+    "    data_config=data_config,\n",
+    "    model_config=model_config,\n",
+    "    optimizer_config=optimizer_config,\n",
+    "    trainer_config=trainer_config,\n",
+    ")"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "7/7 [00:00<00:00, 19.07it/s, loss=0.613, train_loss=0.605, valid_loss=0.612, valid_accuracy=0.676, train_accuracy=0.672]\n",
       "Epoch 20:  71%|███████▏  | 5/7 [00:00<00:00, 16.99it/s, loss=0.608, train_loss=0.634, valid_loss=0.612, valid_accuracy=0.676, train_accuracy=0.67]\n",
@@ -1645,52 +1391,23 @@
      ]
     }
    ],
-   "source": [
-    "data_config = DataConfig(\n",
-    "    target=['target'],\n",
-    "    continuous_cols=num_col_names,\n",
-    "    categorical_cols=cat_col_names,\n",
-    "    continuous_feature_transform=None,#\"yeo-johnson\",\n",
-    "    normalize_continuous_features=True\n",
-    ")\n",
-    "trainer_config = TrainerConfig(\n",
-    "    auto_lr_find=False,\n",
-    "    batch_size=1024,\n",
-    "    max_epochs=1000,\n",
-    "    gpus=1,\n",
-    "    # track_grad_norm=2,\n",
-    "    gradient_clip_val=10,\n",
-    ")\n",
-    "# experiment_config = ExperimentConfig(project_name=\"Tabular_test\", log_logits=True)\n",
-    "optimizer_config = OptimizerConfig()\n",
-    "\n",
-    "model_config = TabNetModelConfig(\n",
-    "    task=\"classification\",\n",
-    "    n_d=5,\n",
-    "    n_a=5,\n",
-    "    n_steps=2,\n",
-    "    n_independent=2,\n",
-    "    n_shared=2,\n",
-    "    learning_rate=1e-3\n",
-    ")\n",
-    "tabular_model = TabularModel(\n",
-    "    data_config=data_config,\n",
-    "    model_config=model_config,\n",
-    "    optimizer_config=optimizer_config,\n",
-    "    trainer_config=trainer_config,\n",
-    ")"
-   ]
+   "metadata": {
+    "Collapsed": "false",
+    "tags": [
+     "outputPrepend"
+    ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "source": [
+    "tabular_model.fit(train=train, test=test)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Testing: 100%|██████████| 3/3 [00:00<00:00, 27.85it/s]--------------------------------------------------------------------------------\n",
       "DATALOADER:0 TEST RESULTS\n",
@@ -1705,28 +1422,27 @@
      ]
     }
    ],
-   "source": [
-    "tabular_model.fit(train=train, test=test)"
-   ]
+   "metadata": {
+    "Collapsed": "false"
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "Collapsed": "false"
-   },
-   "outputs": [],
    "source": [
     "result = tabular_model.evaluate(test)\n",
     "print(result)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "Collapsed": "false"
+   }
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:df_encoder]",
-   "language": "python",
-   "name": "conda-env-df_encoder-py"
+   "name": "python3",
+   "display_name": "Python 3.9.6 64-bit ('pitch_effect': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1738,7 +1454,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.6"
+  },
+  "interpreter": {
+   "hash": "572246634311884dbf575e2c66fbaff9d1d481733d599f410fd23ebcfad6ab4b"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The `classificaiton_with_NODE` notebook is missing a few imports and had several redundant and unused imports. This PR adresses these.

Fixes #33 