### PR TITLE
Remove raise warning in BaseModel

### DIFF
--- a/src/pytorch_tabular/models/base_model.py
+++ b/src/pytorch_tabular/models/base_model.py
@@ -123,13 +123,13 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
         )
         if not WANDB_INSTALLED:
             self.do_log_logits = False
-            raise warnings.warn(
+            warnings.warn(
                 "Wandb is not installed. Please install wandb to log logits. "
                 "You can install wandb using pip install wandb or install PyTorch Tabular using pip install pytorch-tabular[all]"
             )
         if not PLOTLY_INSTALLED:
             self.do_log_logits = False
-            raise warnings.warn(
+            warnings.warn(
                 "Plotly is not installed. Please install plotly to log logits. "
                 "You can install plotly using pip install plotly or install PyTorch Tabular using pip install pytorch-tabular[all]"
             )


### PR DESCRIPTION
Raising warnings result in "type error: exeptions must derive from baseexeption". This happens if wandb or plotly is not installed and should be fixed by this small PR.

Had to redo PR #124 to clean up my branch