### PR TITLE
Update requirements.txt based on `conda-forge` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,17 @@
 torch>=1.8.1
-category-encoders==2.6.*
+category-encoders==2.6
 numpy>=1.17.2
 pandas>=1.1.5
 scikit-learn>=1.0.0
-pytorch-lightning==1.8.*
+pytorch-lightning==1.8
 omegaconf>=2.0.1
-torchmetrics==0.11.*
+torchmetrics==0.11
 tensorboard>=2.2.0, !=2.5.0
-protobuf==3.20.*
+protobuf==3.20
 pytorch-tabnet==4.0
 PyYAML>=5.1, <6.1.0
 # importlib-metadata <1,>=0.12
 matplotlib>3.1
 ipywidgets
-# Use dataclasses backport for Python 3.6.
-dataclasses;python_version=='3.6'
-einops==0.6.*
+einops==0.6
 rich>=10.2.2


### PR DESCRIPTION
It seems that using `.*` in versions causes `conda-forge` builds to [fail](https://github.com/conda-forge/staged-recipes/pull/22269). Also, since Python 3.6 is not supported, there's no need to include `dataclasses` as a dependency.

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--177.org.readthedocs.build/en/177/

<!-- readthedocs-preview pytorch-tabular end -->