### PR TITLE
ci: switch flake8 / ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,15 +55,16 @@ repos:
   #         - mdformat-black
   #         - mdformat_frontmatter
 
-#  - repo: https://github.com/asottile/yesqa
-#    rev: v1.4.0
-#    hooks:
-#      - id: yesqa
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
     hooks:
-      - id: flake8
+      - id: yesqa
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.264
+    hooks:
+      - id: ruff
+        args: ["--fix"]
 
 # exclude: ^docs/
 

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,6 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
-	flake8 pytorch_tabular tests
-
 test: ## run tests quickly with the default Python
 	pytest
 

--- a/examples/__only_for_dev__/adhoc_scaffold.py
+++ b/examples/__only_for_dev__/adhoc_scaffold.py
@@ -53,7 +53,8 @@ from pytorch_tabular.config import DataConfig, OptimizerConfig, TrainerConfig  #
 from pytorch_tabular.models import CategoryEmbeddingModelConfig  # noqa: E402
 
 data_config = DataConfig(
-    # target should always be a list. Multi-targets are only supported for regression. Multi-Task Classification is not implemented
+    # target should always be a list. Multi-targets are only supported for regression.
+    # Multi-Task Classification is not implemented
     target=["target"],
     continuous_cols=num_col_names,
     categorical_cols=cat_col_names,

--- a/examples/__only_for_dev__/adhoc_scaffold.py
+++ b/examples/__only_for_dev__/adhoc_scaffold.py
@@ -53,9 +53,8 @@ from pytorch_tabular.config import DataConfig, OptimizerConfig, TrainerConfig  #
 from pytorch_tabular.models import CategoryEmbeddingModelConfig  # noqa: E402
 
 data_config = DataConfig(
-    target=[
-        "target"
-    ],  # target should always be a list. Multi-targets are only supported for regression. Multi-Task Classification is not implemented
+    # target should always be a list. Multi-targets are only supported for regression. Multi-Task Classification is not implemented
+    target=["target"],
     continuous_cols=num_col_names,
     categorical_cols=cat_col_names,
     continuous_feature_transform="quantile_normal",

--- a/examples/__only_for_dev__/to_test_classification.py
+++ b/examples/__only_for_dev__/to_test_classification.py
@@ -110,7 +110,8 @@ data_config = DataConfig(
     continuous_feature_transform=None,  # "quantile_normal",
     normalize_continuous_features=False,
 )
-# model_config = CategoryEmbeddingModelConfig(task="classification", metrics=["f1","accuracy"], metrics_params=[{"num_classes":num_classes},{}])
+# model_config = CategoryEmbeddingModelConfig(
+#       task="classification", metrics=["f1","accuracy"], metrics_params=[{"num_classes":num_classes},{}])
 # model_config = NodeConfig(
 #     task="classification",
 #     depth=4,

--- a/examples/__only_for_dev__/to_test_dae.py
+++ b/examples/__only_for_dev__/to_test_dae.py
@@ -145,9 +145,9 @@ batch_size = 1024
 lr = 1e-3
 
 data_config = DataConfig(
-    target=[
-        target_name
-    ],  # target should always be a list. Multi-targets are only supported for regression. Multi-Task Classification is not implemented
+    # target should always be a list. Multi-targets are only supported for regression.
+    # Multi-Task Classification is not implemented
+    target=[target_name],
     continuous_cols=num_col_names,
     categorical_cols=cat_col_names,
     continuous_feature_transform="quantile_normal",

--- a/examples/__only_for_dev__/to_test_regression_custom_models.py
+++ b/examples/__only_for_dev__/to_test_regression_custom_models.py
@@ -31,7 +31,8 @@ class MultiStageModelConfig(ModelConfig):
     additional_tree_output_dim: int = field(
         default=3,
         metadata={
-            "help": "The additional output dimensions which is only used to pass through different layers of the architectures. Only the first output_dim outputs will be used for prediction"
+            "help": "The additional output dimensions which is only used to pass through different layers"
+            " of the architectures. Only the first output_dim outputs will be used for prediction"
         },
     )
     depth: int = field(
@@ -41,7 +42,8 @@ class MultiStageModelConfig(ModelConfig):
     choice_function: str = field(
         default="entmax15",
         metadata={
-            "help": "Generates a sparse probability distribution to be used as feature weights(aka, soft feature selection)",
+            "help": "Generates a sparse probability distribution to be used as feature weights"
+            " (aka, soft feature selection)",
             "choices": ["entmax15", "sparsemax"],
         },
     )
@@ -55,7 +57,8 @@ class MultiStageModelConfig(ModelConfig):
     max_features: Optional[int] = field(
         default=None,
         metadata={
-            "help": "If not None, sets a max limit on the number of features to be carried forward from layer to layer in the Dense Architecture"
+            "help": "If not None, sets a max limit on the number of features to be carried forward"
+            " from layer to layer in the Dense Architecture"
         },
     )
     input_dropout: float = field(
@@ -65,7 +68,8 @@ class MultiStageModelConfig(ModelConfig):
     initialize_response: str = field(
         default="normal",
         metadata={
-            "help": "Initializing the response variable in the Oblivious Decision Trees. By default, it is a standard normal distribution",
+            "help": "Initializing the response variable in the Oblivious Decision Trees."
+            " By default, it is a standard normal distribution",
             "choices": ["normal", "uniform"],
         },
     )
@@ -111,13 +115,16 @@ class MultiStageModelConfig(ModelConfig):
     embed_categorical: bool = field(
         default=False,
         metadata={
-            "help": "Flag to embed categorical columns using an Embedding Layer. If turned off, the categorical columns are encoded using LeaveOneOutEncoder"
+            "help": "Flag to embed categorical columns using an Embedding Layer. If turned off,"
+            " the categorical columns are encoded using LeaveOneOutEncoder"
         },
     )
     embedding_dims: Optional[List[int]] = field(
         default=None,
         metadata={
-            "help": "The dimensions of the embedding for each categorical column as a list of tuples (cardinality, embedding_dim). If left empty, will infer using the cardinality of the categorical column using the rule min(50, (x + 1) // 2)"
+            "help": "The dimensions of the embedding for each categorical column as a list of tuples"
+            " (cardinality, embedding_dim). If left empty, will infer using the cardinality"
+            " of the categorical column using the rule min(50, (x + 1) // 2)"
         },
     )
     embedding_dropout: float = field(

--- a/examples/__only_for_dev__/to_test_regression_custom_models.py
+++ b/examples/__only_for_dev__/to_test_regression_custom_models.py
@@ -106,8 +106,8 @@ class MultiStageModelConfig(ModelConfig):
                 By default(1.0), log-temperatures are initialized in such a way that all bin selectors
                 end up in the linear region of sparse-sigmoid. The temperatures are then scaled by this parameter.
                 Setting this value > 1.0 will result in some margin between data points and sparse-sigmoid cutoff value
-                Setting this value < 1.0 will cause (1 - value) part of data points to end up in flat sparse-sigmoid region
-                For instance, threshold_init_cutoff = 0.9 will set 10% points equal to 0.0 or 1.0
+                Setting this value < 1.0 will cause (1 - value) part of data points to end up in flat sparse-sigmoid
+                region. For instance, threshold_init_cutoff = 0.9 will set 10% points equal to 0.0 or 1.0
                 Setting this value > 1.0 will result in a margin between data points and sparse-sigmoid cutoff value
                 All points will be between (0.5 - 0.5 / threshold_init_cutoff) and (0.5 + 0.5 / threshold_init_cutoff)
             """
@@ -314,7 +314,8 @@ model_config = MultiStageModelConfig(
     num_layers=1,  # Number of Dense Layers
     num_trees=2048,  # Number of Trees in each layer
     depth=6,  # Depth of each Tree
-    embed_categorical=True,  # If True, will use a learned embedding, else it will use LeaveOneOutEncoding for categorical columns
+    # If True, will use a learned embedding, else it will use LeaveOneOutEncoding for categorical columns
+    embed_categorical=True,
     learning_rate=0.02,
     additional_tree_output_dim=25,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,39 @@ order_by_type = "False"
 # https://github.com/psf/black
 line-length = 120
 exclude = "(.eggs|.git|.hg|.mypy_cache|.venv|_build|buck-out|build|dist)"
+
+
+[tool.ruff]
+line-length = 120
+# Enable Pyflakes `E` and `F` codes by default.
+select = [
+    "E", "W",  # see: https://pypi.org/project/pycodestyle
+    "F",  # see: https://pypi.org/project/pyflakes
+#    "D",  # see: https://pypi.org/project/pydocstyle
+#    "N",  # see: https://pypi.org/project/pep8-naming
+]
+ignore = [
+    "E731",  # Do not assign a lambda expression, use a def
+]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".eggs",
+    ".git",
+    ".mypy_cache",
+    ".ruff_cache",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "docs"
+]
+ignore-init-module-imports = true
+
+[tool.ruff.per-file-ignores]
+"setup.py" = ["D100", "SIM115"]
+"__about__.py" = ["D100"]
+"__init__.py" = ["D100"]
+
+[tool.ruff.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytorch-lightning >=1.8.0, <1.9.0
 omegaconf >=2.0.1
 torchmetrics >=0.10.0, <0.12.0
 tensorboard >=2.2.0, !=2.5.0
-protobuf >=3.20.0, <3.21.0
+protobuf >=3.20.0, <4.23.0
 pytorch-tabnet ==4.0
 PyYAML >=5.1, <6.1.0
 # importlib-metadata <1,>=0.12

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 pip==23.1.2
 wget
 bump2version==1.0.1
-flake8>=3.7.8
 # coverage>=4.5.4
 mkdocs-material==9.0.*
 mkdocstrings[python]==0.21.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,12 +27,6 @@ replace = __version__ = "{new_version}"
 [bdist_wheel]
 universal = 1
 
-[flake8]
-max-line-length = 120
-exclude = docs
-ignore = W6,E12,W503,E5
-format = pylint
-
 [aliases]
 test = pytest
 

--- a/src/pytorch_tabular/categorical_encoders.py
+++ b/src/pytorch_tabular/categorical_encoders.py
@@ -154,7 +154,8 @@ class CategoricalEmbeddingTransformer(BaseEstimator, TransformerMixin):
             embedding_layer = model.extract_embedding()
         except ValueError as e:
             logger.error(
-                f"Extracting embedding layer from model received this error: {e}. Some models do not support this feature."
+                f"Extracting embedding layer from model received this error: {e}."
+                f" Some models do not support this feature."
             )
             embedding_layer = None
         if embedding_layer is not None:

--- a/src/pytorch_tabular/categorical_encoders.py
+++ b/src/pytorch_tabular/categorical_encoders.py
@@ -197,7 +197,8 @@ class CategoricalEmbeddingTransformer(BaseEstimator, TransformerMixin):
         """
         if not self._mapping:
             raise ValueError(
-                "Passed model should either have an attribute `embeddng_layers` or a method `extract_embedding` defined for `transform`."
+                "Passed model should either have an attribute `embeddng_layers`"
+                " or a method `extract_embedding` defined for `transform`."
             )
         assert all(c in X.columns for c in self.cols)
 

--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -47,7 +47,8 @@ def _validate_choices(cls):
         if atr.init and "choices" in atr.metadata.keys():
             if getattr(cls, key) not in atr.metadata.get("choices"):
                 raise ValueError(
-                    f"{getattr(cls, key)} is not a valid choice for {key}. Please choose from on of the following: {atr.metadata['choices']}"
+                    f"{getattr(cls, key)} is not a valid choice for {key}."
+                    f" Please choose from on of the following: {atr.metadata['choices']}"
                 )
 
 
@@ -98,7 +99,8 @@ class DataConfig:
     target: Optional[List[str]] = field(
         default=None,
         metadata={
-            "help": "A list of strings with the names of the target column(s). It is mandatory for all except SSL tasks."
+            "help": "A list of strings with the names of the target column(s)."
+            " It is mandatory for all except SSL tasks."
         },
     )
     continuous_cols: List = field(
@@ -112,7 +114,8 @@ class DataConfig:
     date_columns: List = field(
         default_factory=list,
         metadata={
-            "help": "(Column names, Freq) tuples of the date fields. For eg. a field named introduction_date and with a monthly frequency should have an entry ('intro_date','M'}"
+            "help": "(Column names, Freq) tuples of the date fields. For eg. a field named"
+            " `introduction_date` and with a monthly frequency should have an entry ('intro_date','M'}"
         },
     )
 
@@ -123,7 +126,8 @@ class DataConfig:
     validation_split: Optional[float] = field(
         default=0.2,
         metadata={
-            "help": "Percentage of Training rows to keep aside as validation. Used only if Validation Data is not given separately"
+            "help": "Percentage of Training rows to keep aside as validation."
+            " Used only if Validation Data is not given separately"
         },
     )
     continuous_feature_transform: Optional[str] = field(
@@ -146,7 +150,10 @@ class DataConfig:
     quantile_noise: int = field(
         default=0,
         metadata={
-            "help": "NOT IMPLEMENTED. If specified fits QuantileTransformer on data with added gaussian noise with std = :quantile_noise: * data.std ; this will cause discrete values to be more separable. Please not that this transformation does NOT apply gaussian noise to the resulting data, the noise is only applied for QuantileTransformer"
+            "help": "NOT IMPLEMENTED. If specified fits QuantileTransformer on data with added gaussian noise"
+            " with std = :quantile_noise: * data.std ; this will cause discrete values to be more separable."
+            " Please not that this transformation does NOT apply gaussian noise to the resulting data,"
+            " the noise is only applied for QuantileTransformer"
         },
     )
     num_workers: Optional[int] = field(

--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -240,7 +240,8 @@ class TrainerConfig:
     Args:
         batch_size (int): Number of samples in each batch of training
 
-        data_aware_init_batch_size (int): Number of samples in each batch of training for the data-aware initialization, when applicable. Defaults to 2000
+        data_aware_init_batch_size (int): Number of samples in each batch of training for the data-aware initialization,
+            when applicable. Defaults to 2000
 
         fast_dev_run (bool): runs n if set to ``n`` (int) else 1 if set to ``True`` batch(es) of train, val
                 and test to find any bugs (ie: a sort of unit test).
@@ -342,13 +343,15 @@ class TrainerConfig:
     data_aware_init_batch_size: int = field(
         default=2000,
         metadata={
-            "help": "Number of samples in each batch of training for the data-aware initialization, when applicable. Defaults to 2000"
+            "help": "Number of samples in each batch of training for the data-aware initialization,"
+            " when applicable. Defaults to 2000"
         },
     )
     fast_dev_run: bool = field(
         default=False,
         metadata={
-            "help": "runs n if set to ``n`` (int) else 1 if set to ``True`` batch(es) of train, val and test to find any bugs (ie: a sort of unit test)."
+            "help": "runs n if set to ``n`` (int) else 1 if set to ``True`` batch(es) of train,"
+            " val and test to find any bugs (ie: a sort of unit test)."
         },
     )
     max_epochs: int = field(default=10, metadata={"help": "Maximum number of epochs to be run"})
@@ -363,45 +366,53 @@ class TrainerConfig:
     gpus: Optional[int] = field(
         default=None,
         metadata={
-            "help": "DEPRECATED: Number of gpus to train on (int). -1 uses all available GPUs. By default uses CPU (None)"
+            "help": "DEPRECATED: Number of gpus to train on (int). -1 uses all available GPUs."
+            " By default uses CPU (None)"
         },
     )
     accelerator: Optional[str] = field(
         default="auto",
         metadata={
-            "help": "The accelerator to use for training. Can be one of 'cpu','gpu','tpu','ipu','auto'. Defaults to 'auto'",
+            "help": "The accelerator to use for training. Can be one of 'cpu','gpu','tpu','ipu','auto'."
+            " Defaults to 'auto'",
             "choices": ["cpu", "gpu", "tpu", "ipu", "auto"],
         },
     )
     devices: Optional[int] = field(
         default=None,
         metadata={
-            "help": "Number of devices to train on (int). -1 uses all available devices. By default uses all available devices (-1)",
+            "help": "Number of devices to train on (int). -1 uses all available devices."
+            " By default uses all available devices (-1)",
         },
     )
     devices_list: Optional[List[int]] = field(
         default=None,
         metadata={
-            "help": "List of devices to train on (list). If specified, takes precedence over `devices` argument. Defaults to None",
+            "help": "List of devices to train on (list). If specified, takes precedence over `devices` argument."
+            " Defaults to None",
         },
     )
 
     accumulate_grad_batches: int = field(
         default=1,
         metadata={
-            "help": "Accumulates grads every k batches or as set up in the dict. Trainer also calls optimizer.step() for the last indivisible step number."
+            "help": "Accumulates grads every k batches or as set up in the dict."
+            " Trainer also calls optimizer.step() for the last indivisible step number."
         },
     )
     auto_lr_find: bool = field(
         default=False,
         metadata={
-            "help": "Runs a learning rate finder algorithm (see this paper) when calling trainer.tune(), to find optimal initial learning rate."
+            "help": "Runs a learning rate finder algorithm (see this paper) when calling trainer.tune(),"
+            " to find optimal initial learning rate."
         },
     )
     auto_select_gpus: bool = field(
         default=True,
         metadata={
-            "help": "If enabled and `devices` is an integer, pick available gpus automatically. This is especially useful when GPUs are configured to be in 'exclusive mode', such that only one process at a time can access them."
+            "help": "If enabled and `devices` is an integer, pick available gpus automatically."
+            " This is especially useful when GPUs are configured to be in 'exclusive mode',"
+            " such that only one process at a time can access them."
         },
     )
     check_val_every_n_epoch: int = field(default=1, metadata={"help": "Check val every n train epochs."})
@@ -409,7 +420,10 @@ class TrainerConfig:
     overfit_batches: float = field(
         default=0.0,
         metadata={
-            "help": "Uses this much data of the training set. If nonzero, will use the same training set for validation and testing. If the training dataloaders have shuffle=True, Lightning will automatically disable it. Useful for quickly debugging or trying to overfit on purpose."
+            "help": "Uses this much data of the training set. If nonzero, will use the same training set"
+            " for validation and testing. If the training dataloaders have shuffle=True,"
+            " Lightning will automatically disable it."
+            " Useful for quickly debugging or trying to overfit on purpose."
         },
     )
     deterministic: bool = field(
@@ -421,14 +435,16 @@ class TrainerConfig:
     profiler: Optional[str] = field(
         default=None,
         metadata={
-            "help": "To profile individual steps during training and assist in identifying bottlenecks. None, simple or advanced, pytorch",
+            "help": "To profile individual steps during training and assist in identifying bottlenecks."
+            " None, simple or advanced, pytorch",
             "choices": [None, "simple", "advanced", "pytorch"],
         },
     )
     early_stopping: Optional[str] = field(
         default="valid_loss",
         metadata={
-            "help": "The loss/metric that needed to be monitored for early stopping. If None, there will be no early stopping"
+            "help": "The loss/metric that needed to be monitored for early stopping."
+            " If None, there will be no early stopping"
         },
     )
     early_stopping_min_delta: float = field(
@@ -449,7 +465,8 @@ class TrainerConfig:
     early_stopping_kwargs: Optional[Dict[str, Any]] = field(
         default_factory=lambda: dict(),
         metadata={
-            "help": "Additional keyword arguments for the early stopping callback. See the documentation for the PyTorch Lightning EarlyStopping callback for more details."
+            "help": "Additional keyword arguments for the early stopping callback."
+            " See the documentation for the PyTorch Lightning EarlyStopping callback for more details."
         },
     )
     checkpoints: Optional[str] = field(
@@ -469,7 +486,9 @@ class TrainerConfig:
     checkpoints_name: Optional[str] = field(
         default=None,
         metadata={
-            "help": "The name under which the models will be saved. If left blank, first it will look for `run_name` in experiment_config and if that is also None then it will use a generic name like task_version."
+            "help": "The name under which the models will be saved. If left blank,"
+            " first it will look for `run_name` in experiment_config and if that is also None"
+            " then it will use a generic name like task_version."
         },
     )
     checkpoints_mode: str = field(
@@ -483,7 +502,8 @@ class TrainerConfig:
     checkpoints_kwargs: Optional[Dict[str, Any]] = field(
         default_factory=lambda: dict(),
         metadata={
-            "help": "Additional keyword arguments for the checkpoints callback. See the documentation for the PyTorch Lightning ModelCheckpoint callback for more details."
+            "help": "Additional keyword arguments for the checkpoints callback. See the documentation"
+            " for the PyTorch Lightning ModelCheckpoint callback for more details."
         },
     )
     load_best: bool = field(
@@ -493,7 +513,8 @@ class TrainerConfig:
     track_grad_norm: int = field(
         default=-1,
         metadata={
-            "help": "Track and Log Gradient Norms in the logger. -1 by default means no tracking. 1 for the L1 norm, 2 for L2 norm, etc."
+            "help": "Track and Log Gradient Norms in the logger. -1 by default means no tracking. "
+            "1 for the L1 norm, 2 for L2 norm, etc."
         },
     )
     progress_bar: str = field(
@@ -513,16 +534,15 @@ class TrainerConfig:
     )
     trainer_kwargs: Dict[str, Any] = field(
         default_factory=dict,
-        metadata={
-            "help": "Additional kwargs to be passed to PyTorch Lightning Trainer. See https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.trainer.html#pytorch_lightning.trainer.Trainer"
-        },
+        metadata={"help": "Additional kwargs to be passed to PyTorch Lightning Trainer."},
     )
 
     def __post_init__(self):
         _validate_choices(self)
         if self.gpus is not None:
             warnings.warn(
-                "The `gpus` argument is deprecated in favor of `accelerator` and will be removed in a future version of PyTorch Tabular. Please use `accelerator='gpu'` instead.",
+                "The `gpus` argument is deprecated in favor of `accelerator` and will be removed in a future version"
+                " of PyTorch Tabular. Please use `accelerator='gpu'` instead.",
                 DeprecationWarning,
             )
             if self.devices is None:
@@ -540,12 +560,14 @@ class TrainerConfig:
         for key in self.early_stopping_kwargs.keys():
             if key in ["min_delta", "mode", "patience"]:
                 raise ValueError(
-                    f"Cannot override {key} in early_stopping_kwargs. Please use the appropriate argument in `TrainerConfig`"
+                    f"Cannot override {key} in early_stopping_kwargs."
+                    f" Please use the appropriate argument in `TrainerConfig`"
                 )
         for key in self.checkpoints_kwargs.keys():
             if key in ["dirpath", "filename", "monitor", "save_top_k", "mode", "every_n_epochs"]:
                 raise ValueError(
-                    f"Cannot override {key} in checkpoints_kwargs. Please use the appropriate argument in `TrainerConfig`"
+                    f"Cannot override {key} in checkpoints_kwargs."
+                    f" Please use the appropriate argument in `TrainerConfig`"
                 )
 
 
@@ -573,20 +595,24 @@ class ExperimentConfig:
     project_name: str = field(
         default=MISSING,
         metadata={
-            "help": "The name of the project under which all runs will be logged. For Tensorboard this defines the folder under which the logs will be saved and for W&B it defines the project name"
+            "help": "The name of the project under which all runs will be logged."
+            " For Tensorboard this defines the folder under which the logs will be saved"
+            " and for W&B it defines the project name"
         },
     )
 
     run_name: Optional[str] = field(
         default=None,
         metadata={
-            "help": "The name of the run; a specific identifier to recognize the run. If left blank, will be assigned a auto-generated name"
+            "help": "The name of the run; a specific identifier to recognize the run."
+            " If left blank, will be assigned a auto-generated name"
         },
     )
     exp_watch: Optional[str] = field(
         default=None,
         metadata={
-            "help": "The level of logging required.  Can be `gradients`, `parameters`, `all` or `None`. Defaults to None",
+            "help": "The level of logging required.  Can be `gradients`, `parameters`, `all` or `None`."
+            " Defaults to None",
             "choices": ["gradients", "parameters", "all", None],
         },
     )
@@ -643,7 +669,8 @@ class OptimizerConfig:
     optimizer: str = field(
         default="Adam",
         metadata={
-            "help": "Any of the standard optimizers from [torch.optim](https://pytorch.org/docs/stable/optim.html#algorithms)."
+            "help": "Any of the standard optimizers from"
+            " [torch.optim](https://pytorch.org/docs/stable/optim.html#algorithms)."
         },
     )
     optimizer_params: Dict = field(
@@ -653,7 +680,9 @@ class OptimizerConfig:
     lr_scheduler: Optional[str] = field(
         default=None,
         metadata={
-            "help": "The name of the LearningRateScheduler to use, if any, from [torch.optim.lr_scheduler](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate). If None, will not use any scheduler. Defaults to `None`",
+            "help": "The name of the LearningRateScheduler to use, if any, from"
+            " https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate."
+            " If None, will not use any scheduler. Defaults to `None`",
         },
     )
     lr_scheduler_params: Optional[Dict] = field(
@@ -680,7 +709,8 @@ class ExperimentRunManager:
         exp_version_manager: str = ".pt_tmp/exp_version_manager.yml",
     ) -> None:
         """The manages the versions of the experiments based on the name. It is a simple dictionary(yaml) based lookup.
-        Primary purpose is to avoid overwriting of saved models while runing the training without changing the experiment name.
+        Primary purpose is to avoid overwriting of saved models while runing the training without changing
+        the experiment name.
 
         Args:
             exp_version_manager (str, optional): The path of the yml file which acts as version control.
@@ -752,7 +782,9 @@ class ModelConfig:
 
     task: str = field(
         metadata={
-            "help": "Specify whether the problem is regression or classification. `backbone` is a task which considers the model as a backbone to generate features. Mostly used internally for SSL and related tasks.",
+            "help": "Specify whether the problem is regression or classification."
+            " `backbone` is a task which considers the model as a backbone to generate features."
+            " Mostly used internally for SSL and related tasks.",
             "choices": ["regression", "classification", "backbone"],
         }
     )
@@ -760,7 +792,8 @@ class ModelConfig:
     head: Optional[str] = field(
         default="LinearHead",
         metadata={
-            "help": "The head to be used for the model. Should be one of the heads defined in `pytorch_tabular.models.common.heads`. Defaults to  LinearHead",
+            "help": "The head to be used for the model. Should be one of the heads defined"
+            " in `pytorch_tabular.models.common.heads`. Defaults to  LinearHead",
             "choices": [None, "LinearHead", "MixtureDensityHead"],
         },
     )
@@ -768,7 +801,8 @@ class ModelConfig:
     head_config: Optional[Dict] = field(
         default_factory=lambda: {"layers": ""},
         metadata={
-            "help": "The config as a dict which defines the head. If left empty, will be initialized as default linear head."
+            "help": "The config as a dict which defines the head."
+            " If left empty, will be initialized as default linear head."
         },
     )
     embedding_dims: Optional[List] = field(
@@ -901,14 +935,16 @@ class SSLModelConfig:
     encoder_config: Optional[ModelConfig] = field(
         default=None,
         metadata={
-            "help": "The config of the encoder to be used for the model. Should be one of the model configs defined in PyTorch Tabular",
+            "help": "The config of the encoder to be used for the model."
+            " Should be one of the model configs defined in PyTorch Tabular",
         },
     )
 
     decoder_config: Optional[ModelConfig] = field(
         default=None,
         metadata={
-            "help": "The config of decoder to be used for the model. Should be one of the model configs defined in PyTorch Tabular. Defaults to nn.Identity",
+            "help": "The config of decoder to be used for the model."
+            " Should be one of the model configs defined in PyTorch Tabular. Defaults to nn.Identity",
         },
     )
 
@@ -927,7 +963,8 @@ class SSLModelConfig:
     batch_norm_continuous_input: bool = field(
         default=True,
         metadata={
-            "help": "If True, we will normalize the continuous layer by passing it through a BatchNorm layer. DEPRECATED - Use head and head_config instead"
+            "help": "If True, we will normalize the continuous layer by passing it through a BatchNorm layer."
+            " DEPRECATED - Use head and head_config instead"
         },
     )
     learning_rate: float = field(

--- a/src/pytorch_tabular/models/autoint/autoint.py
+++ b/src/pytorch_tabular/models/autoint/autoint.py
@@ -123,11 +123,3 @@ class AutoIntModel(BaseModel):
         self._embedding_layer = self._backbone._build_embedding_layer()
         # Head
         self._head = self._get_head_from_config()
-
-    # def extract_embedding(self):
-    #     if self.hparams.categorical_dim > 0:
-    #         return self.embedding_layer.cat_embedding_layers
-    #     else:
-    #         raise ValueError(
-    #             "Model has been trained with no categorical feature and therefore can't be used as a Categorical Encoder"
-    #         )

--- a/src/pytorch_tabular/models/autoint/config.py
+++ b/src/pytorch_tabular/models/autoint/config.py
@@ -145,20 +145,28 @@ class AutoIntConfig(ModelConfig):
     share_embedding: bool = field(
         default=False,
         metadata={
-            "help": "The flag turns on shared embeddings in the input embedding process. The key idea here is to have an embedding for the feature as a whole along with embeddings of each unique values of that column. For more details refer to Appendix A of the TabTransformer paper. Defaults to False"
+            "help": "The flag turns on shared embeddings in the input embedding process."
+            " The key idea here is to have an embedding for the feature as a whole along with embeddings"
+            " of each unique values of that column."
+            " For more details refer to Appendix A of the TabTransformer paper. Defaults to False"
         },
     )
     share_embedding_strategy: Optional[str] = field(
         default="fraction",
         metadata={
-            "help": "There are two strategies in adding shared embeddings. 1. `add` - A separate embedding for the feature is added to the embedding of the unique values of the feature. 2. `fraction` - A fraction of the input embedding is reserved for the shared embedding of the feature. Defaults to fraction.",
+            "help": "There are two strategies in adding shared embeddings."
+            " 1. `add` - A separate embedding for the feature is added to the embedding"
+            " of the unique values of the feature."
+            " 2. `fraction` - A fraction of the input embedding is reserved"
+            " for the shared embedding of the feature. Defaults to fraction.",
             "choices": ["add", "fraction"],
         },
     )
     shared_embedding_fraction: float = field(
         default=0.25,
         metadata={
-            "help": "Fraction of the input_embed_dim to be reserved by the shared embedding. Should be less than one. Defaults to 0.25"
+            "help": "Fraction of the input_embed_dim to be reserved by the shared embedding."
+            " Should be less than one. Defaults to 0.25"
         },
     )
     deep_layers: bool = field(
@@ -172,13 +180,17 @@ class AutoIntConfig(ModelConfig):
     activation: str = field(
         default="ReLU",
         metadata={
-            "help": "The activation type in the deep MLP. The default activaion in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity. Defaults to ReLU"
+            "help": "The activation type in the deep MLP. The default activaion in PyTorch"
+            " like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity."
+            " Defaults to ReLU"
         },
     )
     use_batch_norm: bool = field(
         default=False,
         metadata={
-            "help": "Flag to include a BatchNorm layer after each Linear Layer+DropOut in the deep MLP. Defaults to False"
+            "help": "Flag to include a BatchNorm layer after each Linear Layer+DropOut in the deep MLP."
+            " Defaults to False"
         },
     )
     initialization: str = field(

--- a/src/pytorch_tabular/models/base_model.py
+++ b/src/pytorch_tabular/models/base_model.py
@@ -132,13 +132,15 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
             self.do_log_logits = False
             warnings.warn(
                 "Wandb is not installed. Please install wandb to log logits. "
-                "You can install wandb using pip install wandb or install PyTorch Tabular using pip install pytorch-tabular[all]"
+                "You can install wandb using pip install wandb or install PyTorch Tabular"
+                " using pip install pytorch-tabular[all]"
             )
         if not PLOTLY_INSTALLED:
             self.do_log_logits = False
             warnings.warn(
                 "Plotly is not installed. Please install plotly to log logits. "
-                "You can install plotly using pip install plotly or install PyTorch Tabular using pip install pytorch-tabular[all]"
+                "You can install plotly using pip install plotly or install PyTorch Tabular"
+                " using pip install pytorch-tabular[all]"
             )
 
     @abstractmethod
@@ -378,7 +380,8 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
                 )
         else:
             raise ValueError(
-                "Model has been trained with no categorical feature and therefore can't be used as a Categorical Encoder"
+                "Model has been trained with no categorical feature and therefore can't be used"
+                " as a Categorical Encoder"
             )
 
     def training_step(self, batch, batch_idx):
@@ -440,7 +443,8 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
                 self._lr_scheduler = getattr(torch.optim.lr_scheduler, self.hparams.lr_scheduler)
             except AttributeError as e:
                 logger.error(
-                    f"{self.hparams.lr_scheduler} is not a valid learning rate sheduler defined in the torch.optim.lr_scheduler module"
+                    f"{self.hparams.lr_scheduler} is not a valid learning rate sheduler defined"
+                    f" in the torch.optim.lr_scheduler module"
                 )
                 raise e
             if isinstance(self._lr_scheduler, torch.optim.lr_scheduler._LRScheduler):

--- a/src/pytorch_tabular/models/category_embedding/config.py
+++ b/src/pytorch_tabular/models/category_embedding/config.py
@@ -70,13 +70,17 @@ class CategoryEmbeddingModelConfig(ModelConfig):
     layers: str = field(
         default="128-64-32",
         metadata={
-            "help": "Hyphen-separated number of layers and units in the classification head. eg. 32-64-32. Defaults to 128-64-32"
+            "help": "Hyphen-separated number of layers and units in the classification head. eg. 32-64-32."
+            " Defaults to 128-64-32"
         },
     )
     activation: str = field(
         default="ReLU",
         metadata={
-            "help": "The activation type in the classification head. The default activaion in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity. Defaults to ReLU"
+            "help": "The activation type in the classification head. The default activaion in PyTorch"
+            " like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity."
+            " Defaults to ReLU"
         },
     )
     use_batch_norm: bool = field(
@@ -93,7 +97,8 @@ class CategoryEmbeddingModelConfig(ModelConfig):
     dropout: float = field(
         default=0.0,
         metadata={
-            "help": "probability of an classification element to be zeroed. This is added to each linear layer. Defaults to 0.0"
+            "help": "probability of an classification element to be zeroed."
+            " This is added to each linear layer. Defaults to 0.0"
         },
     )
     _module_src: str = field(default="models.category_embedding")

--- a/src/pytorch_tabular/models/common/activations.py
+++ b/src/pytorch_tabular/models/common/activations.py
@@ -1,4 +1,4 @@
-# noqa W605
+# W605
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/src/pytorch_tabular/models/common/heads/config.py
+++ b/src/pytorch_tabular/models/common/heads/config.py
@@ -6,7 +6,9 @@ from typing import List, Optional
 
 @dataclass
 class LinearHeadConfig:
-    """A model class for Linear Head configuration; serves as a template and documentation. The models take a dictionary as input, but if there are keys which are not present in this model class, it'll throw an exception.
+    """A model class for Linear Head configuration; serves as a template and documentation. The models take a dictionary
+    as input, but if there are keys which are not present in this model class, it'll throw an exception.
+
     Args:
         layers (str): Hyphen-separated number of layers and units in the classification/regression head.
                 eg. 32-64-32. Default is just a mapping from intput dimension to output dimension
@@ -26,13 +28,16 @@ class LinearHeadConfig:
     layers: str = field(
         default="",
         metadata={
-            "help": "Hyphen-separated number of layers and units in the classification/regression head. eg. 32-64-32. Default is just a mapping from intput dimension to output dimension"
+            "help": "Hyphen-separated number of layers and units in the classification/regression head. eg. 32-64-32."
+            " Default is just a mapping from intput dimension to output dimension"
         },
     )
     activation: str = field(
         default="ReLU",
         metadata={
-            "help": "The activation type in the classification head. The default activaion in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity"
+            "help": "The activation type in the classification head. The default activaion in PyTorch"
+            " like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity"
         },
     )
     dropout: float = field(
@@ -111,7 +116,9 @@ class MixtureDensityHeadConfig:
     mu_bias_init: Optional[List] = field(
         default=None,
         metadata={
-            "help": "To initialize the bias parameter of the mu layer to predefined cluster centers. Should be a list with the same length as number of gaussians in the mixture model. It is highly recommended to set the parameter to combat mode collapse. Defaults to None",
+            "help": "To initialize the bias parameter of the mu layer to predefined cluster centers."
+            " Should be a list with the same length as number of gaussians in the mixture model."
+            " It is highly recommended to set the parameter to combat mode collapse. Defaults to None",
         },
     )
 
@@ -144,7 +151,8 @@ class MixtureDensityHeadConfig:
     softmax_temperature: Optional[float] = field(
         default=1,
         metadata={
-            "help": "The temperature to be used in the gumbel softmax of the mixing coefficients. Values less than one leads to sharper transition between the multiple components. Defaults to 1",
+            "help": "The temperature to be used in the gumbel softmax of the mixing coefficients."
+            " Values less than one leads to sharper transition between the multiple components. Defaults to 1",
         },
     )
     n_samples: int = field(
@@ -163,19 +171,22 @@ class MixtureDensityHeadConfig:
     speedup_training: bool = field(
         default=False,
         metadata={
-            "help": "Turning on this parameter does away with sampling during training which speeds up training, but also doesn't give you visibility on train metrics. Defaults to False",
+            "help": "Turning on this parameter does away with sampling during training which speeds up training,"
+            " but also doesn't give you visibility on train metrics. Defaults to False",
         },
     )
     log_debug_plot: bool = field(
         default=False,
         metadata={
-            "help": "Turning on this parameter plots histograms of the mu, sigma, and pi layers in addition to the logits(if log_logits is turned on in experment config). Defaults to False",
+            "help": "Turning on this parameter plots histograms of the mu, sigma, and pi layers in addition"
+            " to the logits(if log_logits is turned on in experment config). Defaults to False",
         },
     )
     input_dim: int = field(
         default=None,
         metadata={
-            "help": "The input dimensions to the head. This will be automatically filled in while initializing from the `backbone.output_dim`",
+            "help": "The input dimensions to the head. This will be automatically filled in while initializing"
+            " from the `backbone.output_dim`",
         },
     )
     _probabilistic: bool = field(default=True)

--- a/src/pytorch_tabular/models/common/layers.py
+++ b/src/pytorch_tabular/models/common/layers.py
@@ -1,4 +1,4 @@
-# noqa W605
+# W605
 import math
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -33,13 +33,13 @@ class PositionWiseFeedForward(nn.Module):
     four times that of the token embedding $d_{model}$.
     So it is sometime also called the expand-and-contract network.
     There is an activation at the hidden layer, which is
-    usually set to ReLU (Rectified Linear Unit) activation, $$\max(0, x)$$
+    usually set to ReLU (Rectified Linear Unit) activation, $$\\max(0, x)$$
     That is, the FFN function is,
-    $$FFN(x, W_1, W_2, b_1, b_2) = \max(0, x W_1 + b_1) W_2 + b_2$$
+    $$FFN(x, W_1, W_2, b_1, b_2) = \\max(0, x W_1 + b_1) W_2 + b_2$$
     where $W_1$, $W_2$, $b_1$ and $b_2$ are learnable parameters.
     Sometimes the
     GELU (Gaussian Error Linear Unit) activation is also used instead of ReLU.
-    $$x \Phi(x)$$ where $\Phi(x) = P(X \le x), X \sim \mathcal{N}(0,1)$
+    $$x \\Phi(x)$$ where $\\Phi(x) = P(X \\le x), X \\sim \\mathcal{N}(0,1)$
     ### Gated Linear Units
     This is a generic implementation that supports different variants including
     [Gated Linear Units](https://arxiv.org/abs/2002.05202) (GLU).

--- a/src/pytorch_tabular/models/ft_transformer/config.py
+++ b/src/pytorch_tabular/models/ft_transformer/config.py
@@ -129,26 +129,35 @@ class FTTransformerConfig(ModelConfig):
     share_embedding: bool = field(
         default=False,
         metadata={
-            "help": "The flag turns on shared embeddings in the input embedding process. The key idea here is to have an embedding for the feature as a whole along with embeddings of each unique values of that column. For more details refer to Appendix A of the TabTransformer paper. Defaults to False"
+            "help": "The flag turns on shared embeddings in the input embedding process."
+            " The key idea here is to have an embedding for the feature as a whole along with embeddings"
+            " of each unique values of that column. For more details refer"
+            " to Appendix A of the TabTransformer paper. Defaults to False"
         },
     )
     share_embedding_strategy: Optional[str] = field(
         default="fraction",
         metadata={
-            "help": "There are two strategies in adding shared embeddings. 1. `add` - A separate embedding for the feature is added to the embedding of the unique values of the feature. 2. `fraction` - A fraction of the input embedding is reserved for the shared embedding of the feature. Defaults to fraction.",
+            "help": "There are two strategies in adding shared embeddings."
+            " 1. `add` - A separate embedding for the feature is added to the embedding"
+            " of the unique values of the feature."
+            " 2. `fraction` - A fraction of the input embedding is reserved"
+            " for the shared embedding of the feature. Defaults to fraction.",
             "choices": ["add", "fraction"],
         },
     )
     shared_embedding_fraction: float = field(
         default=0.25,
         metadata={
-            "help": "Fraction of the input_embed_dim to be reserved by the shared embedding. Should be less than one. Defaults to 0.25"
+            "help": "Fraction of the input_embed_dim to be reserved by the shared embedding."
+            " Should be less than one. Defaults to 0.25"
         },
     )
     attn_feature_importance: bool = field(
         default=True,
         metadata={
-            "help": "If you are facing memory issues, you can turn off feature importance which will not save the attention weights. Defaults to True"
+            "help": "If you are facing memory issues, you can turn off feature importance"
+            " which will not save the attention weights. Defaults to True"
         },
     )
     num_heads: int = field(
@@ -162,7 +171,8 @@ class FTTransformerConfig(ModelConfig):
     transformer_head_dim: Optional[int] = field(
         default=None,
         metadata={
-            "help": "The number of hidden units in the Multi-Headed Attention layers. Defaults to None and will be same as input_dim."
+            "help": "The number of hidden units in the Multi-Headed Attention layers."
+            " Defaults to None and will be same as input_dim."
         },
     )
     attn_dropout: float = field(
@@ -185,7 +195,11 @@ class FTTransformerConfig(ModelConfig):
     transformer_activation: str = field(
         default="GEGLU",
         metadata={
-            "help": "The activation type in the transformer feed forward layers. In addition to the default activation in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity, GEGLU, ReGLU and SwiGLU are also implemented(https://arxiv.org/pdf/2002.05202.pdf). Defaults to GEGLU",
+            "help": "The activation type in the transformer feed forward layers."
+            " In addition to the default activation in PyTorch like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity,"
+            " GEGLU, ReGLU and SwiGLU are also implemented (https://arxiv.org/pdf/2002.05202.pdf)."
+            " Defaults to GEGLU",
         },
     )
     out_ff_layers: Optional[str] = field(
@@ -197,7 +211,10 @@ class FTTransformerConfig(ModelConfig):
     out_ff_activation: Optional[str] = field(
         default=None,
         metadata={
-            "help": "DEPRECATED: The activation type in the deep MLP. The default activaion in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity. Defaults to ReLU"
+            "help": "DEPRECATED: The activation type in the deep MLP. The default activaion in PyTorch"
+            " like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity."
+            " Defaults to ReLU"
         },
     )
     out_ff_dropout: Optional[float] = field(
@@ -227,12 +244,15 @@ class FTTransformerConfig(ModelConfig):
         ]
         if self.head_config != {"layers": ""}:  # If the user has passed a head_config
             warnings.warn(
-                "Ignoring the deprecated arguments, `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`, and `out_ff_initialization` as head_config is passed."
+                "Ignoring the deprecated arguments, `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`,"
+                " and `out_ff_initialization` as head_config is passed."
             )
         else:
             if any([p is not None for p in deprecated_args]):
                 warnings.warn(
-                    "The `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`, and `out_ff_initialization` arguments are deprecated and will be removed next release. Please use head and head_config as an alternative.",
+                    "The `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`, and `out_ff_initialization`"
+                    " arguments are deprecated and will be removed next release."
+                    " Please use head and head_config as an alternative.",
                     DeprecationWarning,
                 )
                 # TODO: Remove this once we deprecate the old config

--- a/src/pytorch_tabular/models/ft_transformer/ft_transformer.py
+++ b/src/pytorch_tabular/models/ft_transformer/ft_transformer.py
@@ -47,7 +47,10 @@ class FTTransformerBackbone(nn.Module):
         assert config.share_embedding_strategy in [
             "add",
             "fraction",
-        ], f"`share_embedding_strategy` should be one of `add` or `fraction`, not {self.hparams.share_embedding_strategy}"
+        ], (
+            "`share_embedding_strategy` should be one of `add` or `fraction`,"
+            f" not {self.hparams.share_embedding_strategy}"
+        )
         self.hparams = config
         self._build_network()
 
@@ -140,14 +143,6 @@ class FTTransformerModel(BaseModel):
         self._embedding_layer = self._backbone._build_embedding_layer()
         # Head
         self._head = self._get_head_from_config()
-
-    # def extract_embedding(self):
-    #     if self.hparams.categorical_dim > 0:
-    #         return self.embedding_layer.cat_embedding_layers
-    #     else:
-    #         raise ValueError(
-    #             "Model has been trained with no categorical feature and therefore can't be used as a Categorical Encoder"
-    #         )
 
     def feature_importance(self):
         if self.hparams.attn_feature_importance:

--- a/src/pytorch_tabular/models/gate/config.py
+++ b/src/pytorch_tabular/models/gate/config.py
@@ -117,7 +117,8 @@ class GatedAdditiveTreeEnsembleConfig(ModelConfig):
     chain_trees: bool = field(
         default=True,
         metadata={
-            "help": "If True, we will chain the trees together. Synonymous to boosting (chaining trees) or bagging (parallel trees). Defaults to True"
+            "help": "If True, we will chain the trees together."
+            " Synonymous to boosting (chaining trees) or bagging (parallel trees). Defaults to True"
         },
     )
     tree_wise_attention: bool = field(

--- a/src/pytorch_tabular/models/mixture_density/config.py
+++ b/src/pytorch_tabular/models/mixture_density/config.py
@@ -59,7 +59,8 @@ class MDNConfig(ModelConfig):
     backbone_config_class: str = field(
         default=None,
         metadata={
-            "help": "The config class for defining the Backbone. The config class should be a valid module path from `models`. e.g. `FTTransformerConfig`"
+            "help": "The config class for defining the Backbone."
+            " The config class should be a valid module path from `models`. e.g. `FTTransformerConfig`"
         },
     )
     backbone_config_params: Dict = field(

--- a/src/pytorch_tabular/models/mixture_density/mdn.py
+++ b/src/pytorch_tabular/models/mixture_density/mdn.py
@@ -66,7 +66,9 @@ class MDNModel(BaseModel):
             callable = getattr(models, callable)
         except ModuleNotFoundError as e:
             logger.error(
-                "`config class` in `backbone_config` is not valid. The config class should be a valid module path from `models`. e.g. `ft_transformer.FTTransformerConfig`."
+                "`config class` in `backbone_config` is not valid."
+                " The config class should be a valid module path from `models`."
+                " e.g. `ft_transformer.FTTransformerConfig`."
             )
             raise e
         assert issubclass(callable, ModelConfig), "`config_class` should be a subclass of `ModelConfig`"

--- a/src/pytorch_tabular/models/node/config.py
+++ b/src/pytorch_tabular/models/node/config.py
@@ -116,7 +116,8 @@ class NodeConfig(ModelConfig):
     additional_tree_output_dim: int = field(
         default=3,
         metadata={
-            "help": "The additional output dimensions which is only used to pass through different layers of the architectures. Only the first output_dim outputs will be used for prediction"
+            "help": "The additional output dimensions which is only used to pass through different layers"
+            " of the architectures. Only the first output_dim outputs will be used for prediction"
         },
     )
     depth: int = field(
@@ -126,7 +127,8 @@ class NodeConfig(ModelConfig):
     choice_function: str = field(
         default="entmax15",
         metadata={
-            "help": "Generates a sparse probability distribution to be used as feature weights(aka, soft feature selection)",
+            "help": "Generates a sparse probability distribution to be used"
+            " as feature weights(aka, soft feature selection)",
             "choices": ["entmax15", "sparsemax"],
         },
     )
@@ -140,7 +142,8 @@ class NodeConfig(ModelConfig):
     max_features: Optional[int] = field(
         default=None,
         metadata={
-            "help": "If not None, sets a max limit on the number of features to be carried forward from layer to layer in the Dense Architecture"
+            "help": "If not None, sets a max limit on the number of features to be carried forward"
+            " from layer to layer in the Dense Architecture"
         },
     )
     input_dropout: float = field(
@@ -150,7 +153,8 @@ class NodeConfig(ModelConfig):
     initialize_response: str = field(
         default="normal",
         metadata={
-            "help": "Initializing the response variable in the Oblivious Decision Trees. By default, it is a standard normal distribution",
+            "help": "Initializing the response variable in the Oblivious Decision Trees."
+            " By default, it is a standard normal distribution",
             "choices": ["normal", "uniform"],
         },
     )
@@ -186,8 +190,8 @@ class NodeConfig(ModelConfig):
                 By default(1.0), log-temperatures are initialized in such a way that all bin selectors
                 end up in the linear region of sparse-sigmoid. The temperatures are then scaled by this parameter.
                 Setting this value > 1.0 will result in some margin between data points and sparse-sigmoid cutoff value
-                Setting this value < 1.0 will cause (1 - value) part of data points to end up in flat sparse-sigmoid region
-                For instance, threshold_init_cutoff = 0.9 will set 10% points equal to 0.0 or 1.0
+                Setting this value < 1.0 will cause (1 - value) part of data points to end up in flat sparse-sigmoid
+                region. For instance, threshold_init_cutoff = 0.9 will set 10% points equal to 0.0 or 1.0
                 Setting this value > 1.0 will result in a margin between data points and sparse-sigmoid cutoff value
                 All points will be between (0.5 - 0.5 / threshold_init_cutoff) and (0.5 + 0.5 / threshold_init_cutoff)
             """
@@ -196,14 +200,17 @@ class NodeConfig(ModelConfig):
     cat_embedding_dropout: float = field(
         default=0.0,
         metadata={
-            "help": "DEPRECATED: Please use `embedding_dropout` instead. probability of an embedding element to be zeroed."
+            "help": "DEPRECATED: Please use `embedding_dropout` instead."
+            " probability of an embedding element to be zeroed."
         },
     )
 
     embed_categorical: bool = field(
         default=False,
         metadata={
-            "help": "Flag to embed categorical columns using an Embedding Layer. If turned off, the categorical columns are encoded using LeaveOneOutEncoder. This is DEPRECATED and will always be `True` from next release."
+            "help": "Flag to embed categorical columns using an Embedding Layer."
+            " If turned off, the categorical columns are encoded using LeaveOneOutEncoder."
+            " This is DEPRECATED and will always be `True` from next release."
         },
     )
 
@@ -216,11 +223,14 @@ class NodeConfig(ModelConfig):
         if not self.embed_categorical:
             # raise deprecation warning
             warnings.warn(
-                "embed_categorical is set to False and will use LeaveOneOutEncoder to encode categorical features. This is deprecated and will be removed in future versions and categorical columns will be embedded by default."
+                "embed_categorical is set to False and will use LeaveOneOutEncoder to encode categorical features."
+                " This is deprecated and will be removed in future versions and categorical columns"
+                " will be embedded by default."
             )
         if self.cat_embedding_dropout > 0:
             warnings.warn(
-                "`cat_embedding_dropout` is deprecated and will be removed in the next release. Please use `embedding_dropout` instead"
+                "`cat_embedding_dropout` is deprecated and will be removed in the next release."
+                " Please use `embedding_dropout` instead"
             )
             self.embedding_dropout = self.cat_embedding_dropout
         super().__post_init__()

--- a/src/pytorch_tabular/models/node/node_model.py
+++ b/src/pytorch_tabular/models/node/node_model.py
@@ -23,7 +23,8 @@ class NODEBackbone(nn.Module):
     def __init__(self, config: DictConfig, **kwargs):
         super().__init__()
         self.hparams = config
-        # self.hparams.output_dim = (0 if self.hparams.output_dim is None else self.hparams.output_dim)  # For SSL cases where output_dim will be None
+        # self.hparams.output_dim = (0 if self.hparams.output_dim is None else self.hparams.output_dim)
+        # For SSL cases where output_dim will be None
         self._build_network()
 
     def _build_network(self):
@@ -115,12 +116,3 @@ class NODEModel(BaseModel):
         # Not using config head because NODE has a specific head
         warnings.warn("Ignoring head config because NODE has a specific head which subsets the tree outputs")
         self._head = Lambda(self.subset)
-
-    # def extract_embedding(self):
-    #     if self.hparams.embed_categorical:
-    #         if self.hparams.embedded_cat_dim != 0:
-    #             return self.embedding_layer.cat_embedding_layers
-    #     else:
-    #         raise ValueError(
-    #             "Model has been trained with no categorical feature and therefore can't be used as a Categorical Encoder"
-    #         )

--- a/src/pytorch_tabular/models/tab_transformer/config.py
+++ b/src/pytorch_tabular/models/tab_transformer/config.py
@@ -126,20 +126,28 @@ class TabTransformerConfig(ModelConfig):
     share_embedding: bool = field(
         default=False,
         metadata={
-            "help": "The flag turns on shared embeddings in the input embedding process. The key idea here is to have an embedding for the feature as a whole along with embeddings of each unique values of that column. For more details refer to Appendix A of the TabTransformer paper. Defaults to False"
+            "help": "The flag turns on shared embeddings in the input embedding process."
+            " The key idea here is to have an embedding for the feature as a whole along with embeddings"
+            " of each unique values of that column. For more details refer"
+            " to Appendix A of the TabTransformer paper. Defaults to False"
         },
     )
     share_embedding_strategy: Optional[str] = field(
         default="fraction",
         metadata={
-            "help": "There are two strategies in adding shared embeddings. 1. `add` - A separate embedding for the feature is added to the embedding of the unique values of the feature. 2. `fraction` - A fraction of the input embedding is reserved for the shared embedding of the feature. Defaults to fraction.",
+            "help": "There are two strategies in adding shared embeddings."
+            " 1. `add` - A separate embedding for the feature is added to the embedding"
+            " of the unique values of the feature."
+            " 2. `fraction` - A fraction of the input embedding is reserved"
+            " for the shared embedding of the feature. Defaults to fraction.",
             "choices": ["add", "fraction"],
         },
     )
     shared_embedding_fraction: float = field(
         default=0.25,
         metadata={
-            "help": "Fraction of the input_embed_dim to be reserved by the shared embedding. Should be less than one. Defaults to 0.25"
+            "help": "Fraction of the input_embed_dim to be reserved by the shared embedding."
+            " Should be less than one. Defaults to 0.25"
         },
     )
     num_heads: int = field(
@@ -153,7 +161,8 @@ class TabTransformerConfig(ModelConfig):
     transformer_head_dim: Optional[int] = field(
         default=None,
         metadata={
-            "help": "The number of hidden units in the Multi-Headed Attention layers. Defaults to None and will be same as input_dim."
+            "help": "The number of hidden units in the Multi-Headed Attention layers."
+            " Defaults to None and will be same as input_dim."
         },
     )
     attn_dropout: float = field(
@@ -175,7 +184,11 @@ class TabTransformerConfig(ModelConfig):
     transformer_activation: str = field(
         default="GEGLU",
         metadata={
-            "help": "The activation type in the transformer feed forward layers. In addition to the default activation in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity, GEGLU, ReGLU and SwiGLU are also implemented(https://arxiv.org/pdf/2002.05202.pdf). Defaults to GEGLU",
+            "help": "The activation type in the transformer feed forward layers."
+            " In addition to the default activation in PyTorch like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity,"
+            " GEGLU, ReGLU and SwiGLU are also implemented(https://arxiv.org/pdf/2002.05202.pdf)."
+            " Defaults to GEGLU",
         },
     )
     out_ff_layers: Optional[str] = field(
@@ -187,7 +200,10 @@ class TabTransformerConfig(ModelConfig):
     out_ff_activation: Optional[str] = field(
         default=None,
         metadata={
-            "help": "DEPRECATED: The activation type in the deep MLP. The default activaion in PyTorch like ReLU, TanH, LeakyReLU, etc. https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity. Defaults to ReLU"
+            "help": "DEPRECATED: The activation type in the deep MLP. The default activaion in PyTorch"
+            " like ReLU, TanH, LeakyReLU, etc."
+            " https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity."
+            " Defaults to ReLU"
         },
     )
     out_ff_dropout: Optional[float] = field(
@@ -217,12 +233,15 @@ class TabTransformerConfig(ModelConfig):
         ]
         if self.head_config != {"layers": ""}:  # If the user has passed a head_config
             warnings.warn(
-                "Ignoring the deprecated arguments, `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`, and `out_ff_initialization` as head_config is passed."
+                "Ignoring the deprecated arguments, `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`,"
+                " and `out_ff_initialization` as head_config is passed."
             )
         else:
             if any([p is not None for p in deprecated_args]):
                 warnings.warn(
-                    "The `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`, and `out_ff_initialization` arguments are deprecated and will be removed next release. Please use head and head_config as an alternative.",
+                    "The `out_ff_layers`, `out_ff_activation`, `out_ff_dropoout`, and `out_ff_initialization`"
+                    " arguments are deprecated and will be removed next release."
+                    " Please use head and head_config as an alternative.",
                     DeprecationWarning,
                 )
                 # TODO: Remove this once we deprecate the old config

--- a/src/pytorch_tabular/models/tab_transformer/tab_transformer.py
+++ b/src/pytorch_tabular/models/tab_transformer/tab_transformer.py
@@ -30,7 +30,10 @@ class TabTransformerBackbone(nn.Module):
         assert config.share_embedding_strategy in [
             "add",
             "fraction",
-        ], f"`share_embedding_strategy` should be one of `add` or `fraction`, not {self.hparams.share_embedding_strategy}"
+        ], (
+            f"`share_embedding_strategy` should be one of `add` or `fraction`,"
+            f" not {self.hparams.share_embedding_strategy}"
+        )
         self.hparams = config
         self._build_network()
 
@@ -122,11 +125,3 @@ class TabTransformerModel(BaseModel):
         # Returns output
         x = self.backbone(x["categorical"], x["continuous"])
         return x
-
-    # def extract_embedding(self):
-    #     if self.hparams.categorical_dim > 0:
-    #         return self.embedding_layer.cat_embedding_layers
-    #     else:
-    #         raise ValueError(
-    #             "Model has been trained with no categorical feature and therefore can't be used as a Categorical Encoder"
-    #         )

--- a/src/pytorch_tabular/ssl_models/base_model.py
+++ b/src/pytorch_tabular/ssl_models/base_model.py
@@ -74,7 +74,8 @@ class SSLBaseModel(pl.LightningModule, metaclass=ABCMeta):
         assert (encoder is not None) or (
             encoder_config is not None
         ), "Either encoder or encoder_config must be provided"
-        # assert (decoder is not None) or (decoder_config is not None), "Either decoder or decoder_config must be provided"
+        # assert (decoder is not None) or (decoder_config is not None),
+        # "Either decoder or decoder_config must be provided"
         if encoder is not None:
             self.encoder = encoder
             self._custom_decoder = True
@@ -190,7 +191,8 @@ class SSLBaseModel(pl.LightningModule, metaclass=ABCMeta):
                 self._lr_scheduler = getattr(torch.optim.lr_scheduler, self.hparams.lr_scheduler)
             except AttributeError as e:
                 logger.error(
-                    f"{self.hparams.lr_scheduler} is not a valid learning rate sheduler defined in the torch.optim.lr_scheduler module"
+                    f"{self.hparams.lr_scheduler} is not a valid learning rate sheduler defined"
+                    f" in the torch.optim.lr_scheduler module"
                 )
                 raise e
             if isinstance(self._lr_scheduler, torch.optim.lr_scheduler._LRScheduler):

--- a/src/pytorch_tabular/ssl_models/common/layers.py
+++ b/src/pytorch_tabular/ssl_models/common/layers.py
@@ -1,4 +1,4 @@
-# noqa W605
+# W605
 from collections import OrderedDict
 from typing import Any, Dict, Tuple
 

--- a/src/pytorch_tabular/ssl_models/dae/config.py
+++ b/src/pytorch_tabular/ssl_models/dae/config.py
@@ -62,7 +62,10 @@ class DenoisingAutoEncoderConfig(SSLModelConfig):
     noise_strategy: str = field(
         default="swap",
         metadata={
-            "help": "Defines what kind of noise we are introducing to samples. `swap` - Swap noise is when we replace values of a feature with random permutations of the same feature. `zero` - Zero noise is when we replace values of a feature with zeros. Defaults to swap",
+            "help": "Defines what kind of noise we are introducing to samples."
+            " `swap` - Swap noise is when we replace values of a feature with random permutations"
+            " of the same feature. `zero` - Zero noise is when we replace values of a feature with zeros."
+            " Defaults to swap",
             "choices": ["swap", "zero"],
         },
     )
@@ -70,19 +73,24 @@ class DenoisingAutoEncoderConfig(SSLModelConfig):
     noise_probabilities: Dict[str, float] = field(
         default_factory=lambda: dict(),
         metadata={
-            "help": "Dict of individual probabilities to corrupt the input features with swap/zero noise. Key should be the feature name and if any feature is missing, the default_noise_probability is used. Default is an empty dict()"
+            "help": "Dict of individual probabilities to corrupt the input features with swap/zero noise."
+            " Key should be the feature name and if any feature is missing,"
+            " the default_noise_probability is used. Default is an empty dict()"
         },
     )
     default_noise_probability: float = field(
         default=0.8,
         metadata={
-            "help": "Default probability to corrupt the input features with swap/zero noise. For features for which noise_probabilities does not define a probability. Default is 0.8"
+            "help": "Default probability to corrupt the input features with swap/zero noise."
+            " For features for which noise_probabilities does not define a probability. Default is 0.8"
         },
     )
     loss_type_weights: Optional[List[float]] = field(
         default=None,
         metadata={
-            "help": "Weights to be used for the loss function in the order [binary, categorical, numerical]. If None, will use the default weights using a formula. eg. for binary, default weight will be n_binary/n_features. Defaults to None"
+            "help": "Weights to be used for the loss function in the order [binary, categorical, numerical]."
+            " If None, will use the default weights using a formula. eg. for binary,"
+            " default weight will be n_binary/n_features. Defaults to None"
         },
     )
     mask_loss_weight: float = field(
@@ -92,7 +100,10 @@ class DenoisingAutoEncoderConfig(SSLModelConfig):
     max_onehot_cardinality: int = field(
         default=4,
         metadata={
-            "help": "Maximum cardinality of one-hot encoded categorical features. Any categorical feature with cardinality>max_onehot_cardinality will be embedded in a learned embedding space and others will be converted to a one hot representation. If set to 0, will use the embedding strategy for all categorical feature. Default is 4"
+            "help": "Maximum cardinality of one-hot encoded categorical features."
+            " Any categorical feature with cardinality>max_onehot_cardinality will be embedded"
+            " in a learned embedding space and others will be converted to a one hot representation."
+            " If set to 0, will use the embedding strategy for all categorical feature. Default is 4"
         },
     )
 

--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -78,8 +78,9 @@ class TabularDatamodule(pl.LightningDataModule):
             test (pd.DataFrame, optional): Holdout DataFrame to check final performance on.
                 Defaults to None.
 
-            target_transform (Optional[Union[TransformerMixin, Tuple(Callable)]], optional): If provided, applies the transform to the target before modelling
-                and inverse the transform during prediction. The parameter can either be a sklearn Transformer which has an inverse_transform method, or
+            target_transform (Optional[Union[TransformerMixin, Tuple(Callable)]], optional):
+                If provided, applies the transform to the target before modelling and inverse the transform during
+                prediction. The parameter can either be a sklearn Transformer which has an inverse_transform method, or
                 a tuple of callables (transform_func, inverse_transform_func)
         """
         super().__init__()
@@ -168,7 +169,8 @@ class TabularDatamodule(pl.LightningDataModule):
                 # Multi-Target Regression uses the first target to encode the categorical columns
                 if len(self.config.target) > 1:
                     logger.warning(
-                        f"Multi-Target Regression: using the first target({self.config.target[0]}) to encode the categorical columns"
+                        f"Multi-Target Regression: using the first target({self.config.target[0]})"
+                        f" to encode the categorical columns"
                     )
                 data = self.categorical_encoder.fit_transform(data, data[self.config.target[0]])
             else:
@@ -242,7 +244,8 @@ class TabularDatamodule(pl.LightningDataModule):
 
         Args:
             data (pd.DataFrame): A dataframe with the features and target
-            stage (str, optional): Internal parameter. Used to distinguisj between fit and inference. Defaults to "inference".
+            stage (str, optional): Internal parameter. Used to distinguisj between fit and inference.
+                Defaults to "inference".
 
         Returns:
             Returns the processed dataframe and the added features(list) as a tuple
@@ -280,13 +283,15 @@ class TabularDatamodule(pl.LightningDataModule):
         before accessing the dataloaders.
 
         Args:
-            stage (Optional[str], optional): Internal parameter to distinguish between fit and inference. Defaults to None.
+            stage (Optional[str], optional):
+                Internal parameter to distinguish between fit and inference. Defaults to None.
         """
         if stage == "fit" or stage is None:
             logger.info(f"Setting up the datamodule for {self.config.task} task")
             if self.validation is None:
                 logger.debug(
-                    f"No validation data provided. Using {self.config.validation_split*100}% of train data as validation"
+                    f"No validation data provided."
+                    f" Using {self.config.validation_split*100}% of train data as validation"
                 )
                 val_idx = self.train.sample(
                     int(self.config.validation_split * len(self.train)),
@@ -653,12 +658,15 @@ class TabularDataset(Dataset):
 
         Args:
             data (pd.DataFrame): Pandas DataFrame to load during training
-            task (str): Whether it is a classification or regression task. If classification, it returns a LongTensor as target
+            task (str):
+                Whether it is a classification or regression task. If classification, it returns a LongTensor as target
             continuous_cols (List[str], optional): A list of names of continuous columns. Defaults to None.
             categorical_cols (List[str], optional): A list of names of categorical columns.
-            These columns must be ordinal encoded beforehand. Defaults to None.
-            embed_categorical (bool): Flag to tell the dataset whether to convert categorical columns to LongTensor or retain as float.
-            If we are going to embed categorical cols with an embedding layer, we need to convert the columns to LongTensor
+                These columns must be ordinal encoded beforehand. Defaults to None.
+            embed_categorical (bool):
+                Flag to tell the dataset whether to convert categorical columns to LongTensor or retain as float.
+                If we are going to embed categorical cols with an embedding layer,
+                we need to convert the columns to LongTensor
             target (List[str], optional): A list of strings with target column name(s). Defaults to None.
         """
 

--- a/src/pytorch_tabular/tabular_model.py
+++ b/src/pytorch_tabular/tabular_model.py
@@ -62,34 +62,37 @@ class TabularModel:
             config (Optional[Union[DictConfig, str]], optional): Single OmegaConf DictConfig object or
                 the path to the yaml file holding all the config parameters. Defaults to None.
 
-            data_config (Optional[Union[DataConfig, str]], optional): DataConfig object or path to the yaml file. Defaults to None.
+            data_config (Optional[Union[DataConfig, str]], optional):
+                DataConfig object or path to the yaml file. Defaults to None.
 
-            model_config (Optional[Union[ModelConfig, str]], optional): A subclass of ModelConfig or path to the yaml file.
+            model_config (Optional[Union[ModelConfig, str]], optional):
+                A subclass of ModelConfig or path to the yaml file.
                 Determines which model to run from the type of config. Defaults to None.
 
-            optimizer_config (Optional[Union[OptimizerConfig, str]], optional): OptimizerConfig object or path to the yaml file.
-                Defaults to None.
+            optimizer_config (Optional[Union[OptimizerConfig, str]], optional):
+                OptimizerConfig object or path to the yaml file. Defaults to None.
 
-            trainer_config (Optional[Union[TrainerConfig, str]], optional): TrainerConfig object or path to the yaml file.
-                Defaults to None.
+            trainer_config (Optional[Union[TrainerConfig, str]], optional):
+                TrainerConfig object or path to the yaml file. Defaults to None.
 
-            experiment_config (Optional[Union[ExperimentConfig, str]], optional): ExperimentConfig object or path to the yaml file.
+            experiment_config (Optional[Union[ExperimentConfig, str]], optional):
+                ExperimentConfig object or path to the yaml file.
                 If Provided configures the experiment tracking. Defaults to None.
 
-            model_callable (Optional[Callable], optional): If provided, will override the model callable that will be loaded from the config.
+            model_callable (Optional[Callable], optional):
+                If provided, will override the model callable that will be loaded from the config.
                 Typically used when providing Custom Models
 
-            model_state_dict_path (Optional[Union[str, Path]], optional): If provided, will load the state dict after initializing the model from config.
+            model_state_dict_path (Optional[Union[str, Path]], optional):
+                If provided, will load the state dict after initializing the model from config.
         """
         super().__init__()
         self.exp_manager = ExperimentRunManager()
         if config is None:
-            assert (
-                (data_config is not None)
-                or (model_config is not None)
-                or (optimizer_config is not None)
-                or (trainer_config is not None)
-            ), "If `config` is None, `data_config`, `model_config`, `trainer_config`, and `optimizer_config` cannot be None"
+            assert any(c is not None for c in (data_config, model_config, optimizer_config, trainer_config)), (
+                "If `config` is None, `data_config`, `model_config`, `trainer_config`,"
+                " and `optimizer_config` cannot be None"
+            )
             data_config = self._read_parse_config(data_config, DataConfig)
             model_config = self._read_parse_config(model_config, ModelConfig)
             trainer_config = self._read_parse_config(trainer_config, TrainerConfig)
@@ -156,7 +159,8 @@ class TabularModel:
                     or any([range_[0] > range_[1] for range_ in self.config.target_range])
                 ):
                     raise ValueError(
-                        "Targe Range, if defined, should be list tuples of length two(min,max). The length of the list should be equal to hte length of target columns"
+                        "Targe Range, if defined, should be list tuples of length two(min,max)."
+                        " The length of the list should be equal to hte length of target columns"
                     )
         if self.config.task == "ssl":
             assert (
@@ -438,16 +442,21 @@ class TabularModel:
         Args:
             train (pd.DataFrame): Training Dataframe
 
-            validation (Optional[pd.DataFrame], optional): If provided, will use this dataframe as the validation while training.
-                Used in Early Stopping and Logging. If left empty, will use 20% of Train data as validation. Defaults to None.
+            validation (Optional[pd.DataFrame], optional):
+                If provided, will use this dataframe as the validation while training.
+                Used in Early Stopping and Logging. If left empty, will use 20% of Train data as validation.
+                Defaults to None.
 
             test (Optional[pd.DataFrame], optional): If provided, will use as the hold-out data,
                 which you'll be able to check performance after the model is trained. Defaults to None.
 
-            train_sampler (Optional[torch.utils.data.Sampler], optional): Custom PyTorch batch samplers which will be passed to the DataLoaders. Useful for dealing with imbalanced data and other custom batching strategies
+            train_sampler (Optional[torch.utils.data.Sampler], optional):
+                Custom PyTorch batch samplers which will be passed to the DataLoaders.
+                Useful for dealing with imbalanced data and other custom batching strategies
 
-            target_transform (Optional[Union[TransformerMixin, Tuple(Callable)]], optional): If provided, applies the transform to the target before modelling
-                and inverse the transform during prediction. The parameter can either be a sklearn Transformer which has an inverse_transform method, or
+            target_transform (Optional[Union[TransformerMixin, Tuple(Callable)]], optional):
+                If provided, applies the transform to the target before modelling and inverse the transform during
+                prediction. The parameter can either be a sklearn Transformer which has an inverse_transform method, or
                 a tuple of callables (transform_func, inverse_transform_func)
 
             seed (Optional[int], optional): Random seed for reproducibility. Defaults to 42.
@@ -457,7 +466,8 @@ class TabularModel:
         """
         if test is not None:
             warnings.warn(
-                "Providing test data in `fit` is deprecated and will be removed in next major release. Plese use `evaluate` for evaluating on test data"
+                "Providing test data in `fit` is deprecated and will be removed in next major release."
+                " Plese use `evaluate` for evaluating on test data"
             )
         logger.info("Preparing the DataLoaders")
         target_transform = self._check_and_set_target_transform(target_transform)
@@ -493,7 +503,8 @@ class TabularModel:
             metrics (Optional[List[Callable]], optional): Custom metric functions(Callable) which has the
                 signature metric_fn(y_hat, y) and works on torch tensor inputs
 
-            optimizer (Optional[torch.optim.Optimizer], optional): Custom optimizers which are a drop in replacements for standard PyToch optimizers.
+            optimizer (Optional[torch.optim.Optimizer], optional):
+                Custom optimizers which are a drop in replacements for standard PyToch optimizers.
                 This should be the Class and not the initialized object
 
             optimizer_params (Optional[Dict], optional): The parmeters to initialize the custom optimizer.
@@ -535,7 +546,8 @@ class TabularModel:
 
             datamodule (TabularDatamodule): The datamodule
 
-            callbacks (Optional[List[pl.Callback]], optional): List of callbacks to be used during training. Defaults to None.
+            callbacks (Optional[List[pl.Callback]], optional):
+                List of callbacks to be used during training. Defaults to None.
 
             max_epochs (Optional[int]): Overwrite maximum number of epochs to be run. Defaults to None.
 
@@ -554,7 +566,8 @@ class TabularModel:
             logger.info("Auto LR Find Started")
             result = self.trainer.tune(self.model, train_loader, val_loader)
             logger.info(
-                f"Suggested LR: {result['lr_find'].suggestion()}. For plot and detailed analysis, use `find_learning_rate` method."
+                f"Suggested LR: {result['lr_find'].suggestion()}."
+                f" For plot and detailed analysis, use `find_learning_rate` method."
             )
             # Parameters in models needs to be initialized again after LR find
             self.model.data_aware_initialization(self.datamodule)
@@ -588,8 +601,10 @@ class TabularModel:
         Args:
             train (pd.DataFrame): Training Dataframe
 
-            validation (Optional[pd.DataFrame], optional): If provided, will use this dataframe as the validation while training.
-                Used in Early Stopping and Logging. If left empty, will use 20% of Train data as validation. Defaults to None.
+            validation (Optional[pd.DataFrame], optional):
+                If provided, will use this dataframe as the validation while training.
+                Used in Early Stopping and Logging. If left empty, will use 20% of Train data as validation.
+                Defaults to None.
 
             test (Optional[pd.DataFrame], optional): If provided, will use as the hold-out data,
                 which you'll be able to check performance after the model is trained. Defaults to None.
@@ -600,16 +615,19 @@ class TabularModel:
             metrics (Optional[List[Callable]], optional): Custom metric functions(Callable) which has the
                 signature metric_fn(y_hat, y) and works on torch tensor inputs
 
-            optimizer (Optional[torch.optim.Optimizer], optional): Custom optimizers which are a drop in replacements for
+            optimizer (Optional[torch.optim.Optimizer], optional):
+                Custom optimizers which are a drop in replacements for
                 standard PyToch optimizers. This should be the Class and not the initialized object
 
             optimizer_params (Optional[Dict], optional): The parmeters to initialize the custom optimizer.
 
-            train_sampler (Optional[torch.utils.data.Sampler], optional): Custom PyTorch batch samplers which will be passed
+            train_sampler (Optional[torch.utils.data.Sampler], optional):
+                Custom PyTorch batch samplers which will be passed
                 to the DataLoaders. Useful for dealing with imbalanced data and other custom batching strategies
 
-            target_transform (Optional[Union[TransformerMixin, Tuple(Callable)]], optional): If provided, applies the transform to the
-                target before modelling and inverse the transform during prediction. The parameter can either be a sklearn Transformer
+            target_transform (Optional[Union[TransformerMixin, Tuple(Callable)]], optional):
+                If provided, applies the transform to the target before modelling and inverse the transform during
+                prediction. The parameter can either be a sklearn Transformer
                 which has an inverse_transform method, or a tuple of callables (transform_func, inverse_transform_func)
 
             max_epochs (Optional[int]): Overwrite maximum number of epochs to be run. Defaults to None.
@@ -618,10 +636,12 @@ class TabularModel:
 
             seed: (int): Random seed for reproducibility. Defaults to 42.
 
-            callbacks (Optional[List[pl.Callback]], optional): List of callbacks to be used during training. Defaults to None.
+            callbacks (Optional[List[pl.Callback]], optional):
+                List of callbacks to be used during training. Defaults to None.
 
-            datamodule (Optional[TabularDatamodule], optional): The datamodule. If provided, will ignore the rest of the parameters
-                like train, test etc and use the datamodule. Defaults to None.
+            datamodule (Optional[TabularDatamodule], optional): The datamodule.
+                If provided, will ignore the rest of the parameters like train, test etc and use the datamodule.
+                Defaults to None.
 
         Returns:
             pl.Trainer: The PyTorch Lightning Trainer instance
@@ -636,11 +656,13 @@ class TabularModel:
         else:
             if train is not None:
                 warnings.warn(
-                    "train data is provided but datamodule is provided. Ignoring the train data and using the datamodule"
+                    "train data is provided but datamodule is provided."
+                    " Ignoring the train data and using the datamodule"
                 )
             if test is not None:
                 warnings.warn(
-                    "Providing test data in `fit` is deprecated and will be removed in next major release. Plese use `evaluate` for evaluating on test data"
+                    "Providing test data in `fit` is deprecated and will be removed in next major release."
+                    " Plese use `evaluate` for evaluating on test data"
                 )
         model = self.prepare_model(
             datamodule,
@@ -762,18 +784,21 @@ class TabularModel:
             experiment_config (Optional[ExperimentConfig], optional):
                 If provided, will redefine the experiment for fine-tuning stage. Defaults to None.
 
-            loss (Optional[torch.nn.Module], optional): If provided, will be used as the loss function for the fine-tuning.
+            loss (Optional[torch.nn.Module], optional):
+                If provided, will be used as the loss function for the fine-tuning.
                 By Default it is MSELoss for regression and CrossEntropyLoss for classification.
 
             metrics (Optional[List[Callable]], optional): List of metrics (either callables or str) to be used for the
-                fine-tuning stage. If str, it should be one of the functional metrics implemented in ``torchmetrics.functional``
-                Defaults to None.
+                fine-tuning stage. If str, it should be one of the functional metrics implemented in
+                ``torchmetrics.functional``. Defaults to None.
 
             metrics_params (Optional[Dict], optional): The parameters for the metrics in the same order as metrics.
-                For eg. f1_score for multi-class needs a parameter `average` to fully define the metric. Defaults to None.
+                For eg. f1_score for multi-class needs a parameter `average` to fully define the metric.
+                Defaults to None.
 
-            optimizer (Optional[torch.optim.Optimizer], optional): Custom optimizers which are a drop in replacements for
-                standard PyTorch optimizers. If provided, the OptimizerConfig is ignored in favor of this. Defaults to None.
+            optimizer (Optional[torch.optim.Optimizer], optional):
+                Custom optimizers which are a drop in replacements for standard PyTorch optimizers. If provided,
+                the OptimizerConfig is ignored in favor of this. Defaults to None.
 
             optimizer_params (Dict, optional): The parameters for the optimizer. Defaults to {}.
 

--- a/src/pytorch_tabular/tabular_model.py
+++ b/src/pytorch_tabular/tabular_model.py
@@ -674,11 +674,12 @@ class TabularModel:
         Args:
             train (pd.DataFrame): Training Dataframe
 
-            validation (Optional[pd.DataFrame], optional): If provided, will use this dataframe as the validation while training.
-                Used in Early Stopping and Logging. If left empty, will use 20% of Train data as validation. Defaults to None.
+            validation (Optional[pd.DataFrame], optional): If provided, will use this dataframe as the validation while
+                training. Used in Early Stopping and Logging. If left empty, will use 20% of Train data as validation.
+                Defaults to None.
 
-            optimizer (Optional[torch.optim.Optimizer], optional): Custom optimizers which are a drop in replacements for
-                standard PyToch optimizers. This should be the Class and not the initialized object
+            optimizer (Optional[torch.optim.Optimizer], optional): Custom optimizers which are a drop in replacements
+                for standard PyToch optimizers. This should be the Class and not the initialized object
 
             optimizer_params (Optional[Dict], optional): The parmeters to initialize the custom optimizer.
 
@@ -688,7 +689,8 @@ class TabularModel:
 
             seed: (int): Random seed for reproducibility. Defaults to 42.
 
-            callbacks (Optional[List[pl.Callback]], optional): List of callbacks to be used during training. Defaults to None.
+            callbacks (Optional[List[pl.Callback]], optional): List of callbacks to be used during training.
+                Defaults to None.
 
             datamodule (Optional[TabularDatamodule], optional): The datamodule. If provided, will ignore the rest of the
                 parameters like train, test etc and use the datamodule. Defaults to None.
@@ -713,7 +715,8 @@ class TabularModel:
         else:
             if train is not None:
                 warnings.warn(
-                    "train data is provided but datamodule is provided. Ignoring the train data and using the datamodule"
+                    "train data is provided but datamodule is provided."
+                    " Ignoring the train data and using the datamodule"
                 )
         model = self.prepare_model(
             datamodule,
@@ -754,14 +757,14 @@ class TabularModel:
             target (Optional[str], optional): The target column name if not provided in the initial pretraining stage.
                 Defaults to None.
 
-            optimizer_config (Optional[OptimizerConfig], optional): If provided, will redefine the optimizer for fine-tuning
-                stage. Defaults to None.
+            optimizer_config (Optional[OptimizerConfig], optional):
+                If provided, will redefine the optimizer for fine-tuning stage. Defaults to None.
 
-            trainer_config (Optional[TrainerConfig], optional): If provided, will redefine the trainer for fine-tuning stage.
-                Defaults to None.
+            trainer_config (Optional[TrainerConfig], optional):
+                If provided, will redefine the trainer for fine-tuning stage. Defaults to None.
 
-            experiment_config (Optional[ExperimentConfig], optional): If provided, will redefine the experiment for fine-tuning
-                stage. Defaults to None.
+            experiment_config (Optional[ExperimentConfig], optional):
+                If provided, will redefine the experiment for fine-tuning stage. Defaults to None.
 
             loss (Optional[torch.nn.Module], optional): If provided, will be used as the loss function for the fine-tuning.
                 By Default it is MSELoss for regression and CrossEntropyLoss for classification.
@@ -902,8 +905,8 @@ class TabularModel:
             train_sampler (Optional[torch.utils.data.Sampler], optional): If provided, will be used as a batch sampler
                 for training. Defaults to None.
 
-            target_transform (Optional[Union[TransformerMixin, Tuple]], optional): If provided, will be used to transform
-                the target before training and inverse transform the predictions.
+            target_transform (Optional[Union[TransformerMixin, Tuple]], optional): If provided, will be used
+                to transform the target before training and inverse transform the predictions.
 
             max_epochs (Optional[int], optional): The maximum number of epochs to train for. Defaults to None.
 
@@ -914,8 +917,8 @@ class TabularModel:
             callbacks (Optional[List[pl.Callback]], optional): If provided, will be added to the callbacks for Trainer.
                 Defaults to None.
 
-            datamodule (Optional[TabularDatamodule], optional): If provided, will be used as the datamodule for training.
-                Defaults to None.
+            datamodule (Optional[TabularDatamodule], optional): If provided, will be used as the datamodule
+                for training. Defaults to None.
 
             freeze_backbone (bool, optional): If True, will freeze the backbone by tirning off gradients.
                 Defaults to False, which means the pretrained weights are also further tuned during fine-tuning.
@@ -952,7 +955,8 @@ class TabularModel:
         else:
             if train is not None:
                 warnings.warn(
-                    "train data is provided but datamodule is provided. Ignoring the train data and using the datamodule"
+                    "train data is provided but datamodule is provided."
+                    " Ignoring the train data and using the datamodule"
                 )
         if freeze_backbone:
             for param in self.model.backbone.parameters():
@@ -977,7 +981,8 @@ class TabularModel:
         plot: bool = True,
         callbacks: Optional[List] = None,
     ) -> Tuple[float, pd.DataFrame]:
-        """Enables the user to do a range test of good initial learning rates, to reduce the amount of guesswork in picking a good starting learning rate.
+        """Enables the user to do a range test of good initial learning rates, to reduce the amount of guesswork
+        in picking a good starting learning rate.
 
         Args:
             model (pl.LightningModule): The PyTorch Lightning model to be trained.
@@ -1048,8 +1053,8 @@ class TabularModel:
                 DEPRECATION: providing test data during fit is deprecated and will be removed in a future release.
                 Defaults to None.
 
-            ckpt_path (Optional[Union[str, Path]], optional): The path to the checkpoint to be loaded. If not provided, will try to use the
-                best checkpoint during training.
+            ckpt_path (Optional[Union[str, Path]], optional): The path to the checkpoint to be loaded. If not provided,
+                will try to use the best checkpoint during training.
 
             verbose (bool, optional): If true, will print the results. Defaults to True.
         Returns:
@@ -1057,14 +1062,16 @@ class TabularModel:
         """
         if test_loader is None and test is None:
             warnings.warn(
-                "Providing test in fit is deprecated. Not providing `test` or `test_loader` in `evaluate` will cause an error in a future release."
+                "Providing test in fit is deprecated."
+                " Not providing `test` or `test_loader` in `evaluate` will cause an error in a future release."
             )
         if test_loader is None:
             if test is not None:
                 test_loader = self.datamodule.prepare_inference_dataloader(test)
             elif self.datamodule.test is not None:
                 warnings.warn(
-                    "Providing test in fit is deprecated. Not providing `test` or `test_loader` in `evaluate` will cause an error in a future release."
+                    "Providing test in fit is deprecated."
+                    " Not providing `test` or `test_loader` in `evaluate` will cause an error in a future release."
                 )
                 test_loader = self.datamodule.test_dataloader()
             else:
@@ -1105,7 +1112,8 @@ class TabularModel:
                 If classification, it returns probabilities and final prediction
         """
         warnings.warn(
-            "Default for `include_input_features` will change from True to False in the next release. Please set it explicitly.",
+            "Default for `include_input_features` will change from True to False in the next release."
+            " Please set it explicitly.",
             DeprecationWarning,
         )
         assert all([q <= 1 and q >= 0 for q in quantiles]), "Quantiles should be a decimal between 0 and 1"


### PR DESCRIPTION
the advantage of Ruff over Flake8 is that it is much faster nad also perform fixing

cc: @manujosephv

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--191.org.readthedocs.build/en/191/

<!-- readthedocs-preview pytorch-tabular end -->