### PR TITLE
enable pyupgrade for py3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
       - id: check-docstring-first
       - id: detect-private-key
 
-#  - repo: https://github.com/asottile/pyupgrade
-#    rev: v3.3.1
-#    hooks:
-#      - id: pyupgrade
-#        args: [--py37-plus]
-#        name: Upgrade code
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
+        name: Upgrade code
 
 #  - repo: https://github.com/PyCQA/docformatter
 #    rev: v1.5.1

--- a/src/pytorch_tabular/categorical_encoders.py
+++ b/src/pytorch_tabular/categorical_encoders.py
@@ -3,7 +3,6 @@
 # For license information, see LICENSE.TXT
 # Modified https://github.com/tcassou/mlencoders/blob/master/mlencoders/base_encoder.py to suit NN encoding
 """Category Encoders"""
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 try:
     import cPickle as pickle
@@ -21,7 +20,7 @@ logger = get_logger(__name__)
 NAN_CATEGORY = 0
 
 
-class BaseEncoder(object):
+class BaseEncoder:
     def __init__(self, cols, handle_unseen, min_samples, imputed, handle_missing):
         self.cols = cols
         self.handle_unseen = handle_unseen
@@ -54,7 +53,7 @@ class BaseEncoder(object):
                 X_encoded[col].fillna(self._imputed, inplace=True)
             elif self.handle_unseen == "error":
                 if np.unique(X_encoded[col]).shape[0] > mapping.shape[0]:
-                    raise ValueError("Unseen categories found in `{}` column.".format(col))
+                    raise ValueError(f"Unseen categories found in `{col}` column.")
 
         return X_encoded
 
@@ -72,7 +71,7 @@ class BaseEncoder(object):
 
     def _input_check(self, name, value, options):
         if value not in options:
-            raise ValueError("Wrong input: {} parameter must be in {}".format(name, options))
+            raise ValueError(f"Wrong input: {name} parameter must be in {options}")
 
     def _before_fit_check(self, X, y):
         # Checking columns to encode
@@ -111,7 +110,7 @@ class OrdinalEncoder(BaseEncoder):
         """
         self._input_check("handle_unseen", handle_unseen, ["error", "ignore", "impute"])
         self._input_check("handle_missing", handle_missing, ["error", "impute"])
-        super(OrdinalEncoder, self).__init__(cols, handle_unseen, 1, NAN_CATEGORY, handle_missing)
+        super().__init__(cols, handle_unseen, 1, NAN_CATEGORY, handle_missing)
 
     def fit(self, X, y=None):
         """Label Encode given columns of X.

--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -36,7 +36,7 @@ def _read_yaml(filename):
         ),
         list("-+0123456789."),
     )
-    with open(filename, "r") as file:
+    with open(filename) as file:
         config = yaml.load(file, loader)
     return config
 

--- a/src/pytorch_tabular/models/common/layers.py
+++ b/src/pytorch_tabular/models/common/layers.py
@@ -21,7 +21,7 @@ class Residual(nn.Module):
 
 # https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/labml_nn/transformers/feed_forward.py
 class PositionWiseFeedForward(nn.Module):
-    """
+    r"""
     title: Position-wise Feed-Forward Network (FFN)
     summary: Documented reusable implementation of the position wise feedforward network.
 
@@ -115,7 +115,7 @@ class AddNorm(nn.Module):
     """
 
     def __init__(self, input_dim: int, dropout: float):
-        super(AddNorm, self).__init__()
+        super().__init__()
         self.dropout = nn.Dropout(dropout)
         self.ln = nn.LayerNorm(input_dim)
 
@@ -176,7 +176,7 @@ class SharedEmbeddings(nn.Module):
         add_shared_embed: bool = False,
         frac_shared_embed: float = 0.25,
     ):
-        super(SharedEmbeddings, self).__init__()
+        super().__init__()
         assert frac_shared_embed < 1, "'frac_shared_embed' must be less than 1"
 
         self.add_shared_embed = add_shared_embed
@@ -231,7 +231,7 @@ class PreEncoded1dLayer(nn.Module):
         embedding_dropout: float = 0.0,
         batch_norm_continuous_input: bool = False,
     ):
-        super(PreEncoded1dLayer, self).__init__()
+        super().__init__()
         self.continuous_dim = continuous_dim
         self.categorical_dim = categorical_dim
         self.batch_norm_continuous_input = batch_norm_continuous_input
@@ -286,7 +286,7 @@ class Embedding1dLayer(nn.Module):
         embedding_dropout: float = 0.0,
         batch_norm_continuous_input: bool = False,
     ):
-        super(Embedding1dLayer, self).__init__()
+        super().__init__()
         self.continuous_dim = continuous_dim
         self.categorical_embedding_dims = categorical_embedding_dims
         self.batch_norm_continuous_input = batch_norm_continuous_input
@@ -366,7 +366,7 @@ class Embedding2dLayer(nn.Module):
             batch_norm_continuous_input: whether to use batch norm on continuous features
             embedding_dropout: dropout to apply to embeddings
             initialization: initialization strategy to use for embedding layers"""
-        super(Embedding2dLayer, self).__init__()
+        super().__init__()
         self.continuous_dim = continuous_dim
         self.categorical_cardinality = categorical_cardinality
         self.embedding_dim = embedding_dim

--- a/src/pytorch_tabular/models/gate/components.py
+++ b/src/pytorch_tabular/models/gate/components.py
@@ -87,7 +87,7 @@ class NeuralDecisionTree(nn.Module):
         for d in range(self.depth):
             for n in range(max(2 ** (d), 1)):
                 self.add_module(
-                    "decision_stump_{}_{}".format(d, n),
+                    f"decision_stump_{d}_{n}",
                     NeuralDecisionStump(
                         self.n_features + (2 ** (d) if d > 0 else 0),
                         self.binning_activation,
@@ -103,7 +103,7 @@ class NeuralDecisionTree(nn.Module):
             layer_nodes = []
             layer_feature_masks = []
             for n in range(max(2 ** (d), 1)):
-                leaf_nodes, feature_mask = self._modules["decision_stump_{}_{}".format(d, n)](tree_input)
+                leaf_nodes, feature_mask = self._modules[f"decision_stump_{d}_{n}"](tree_input)
                 layer_nodes.append(leaf_nodes)
                 layer_feature_masks.append(feature_mask)
             layer_nodes = torch.cat(layer_nodes, dim=1)

--- a/src/pytorch_tabular/ssl_models/common/layers.py
+++ b/src/pytorch_tabular/ssl_models/common/layers.py
@@ -21,7 +21,7 @@ class MixedEmbedding1dLayer(nn.Module):
         embedding_dropout: float = 0.0,
         batch_norm_continuous_input: bool = False,
     ):
-        super(MixedEmbedding1dLayer, self).__init__()
+        super().__init__()
         self.continuous_dim = continuous_dim
         self.categorical_embedding_dims = categorical_embedding_dims
         self.categorical_dim = len(categorical_embedding_dims)

--- a/src/pytorch_tabular/ssl_models/common/noise_generators.py
+++ b/src/pytorch_tabular/ssl_models/common/noise_generators.py
@@ -19,7 +19,7 @@ class SwapNoiseCorrupter(nn.Module):
         self.probas = torch.from_numpy(np.array(probas))
 
     def forward(self, x):
-        should_swap = torch.bernoulli(self.probas.to(x.device) * torch.ones((x.shape)).to(x.device))
+        should_swap = torch.bernoulli(self.probas.to(x.device) * torch.ones(x.shape).to(x.device))
         corrupted_x = torch.where(should_swap == 1, x[torch.randperm(x.shape[0])], x)
         mask = (corrupted_x != x).float()
         return corrupted_x, mask


### PR DESCRIPTION
as py3.7 is set as min python version we can also enable this hook

cc: @manujosephv

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--192.org.readthedocs.build/en/192/

<!-- readthedocs-preview pytorch-tabular end -->