### PR TITLE
Fix metrics_prob_inputs naming error

### DIFF
--- a/src/pytorch_tabular/models/base_model.py
+++ b/src/pytorch_tabular/models/base_model.py
@@ -259,7 +259,7 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
         """
         metrics = []
         for metric, metric_str, prob_inp, metric_params in zip(
-            self.metrics, self.hparams.metrics, self.hparams.metrics_prob_inputs, self.hparams.metrics_params
+            self.metrics, self.hparams.metrics, self.hparams.metrics_prob_input, self.hparams.metrics_params
         ):
             if self.hparams.task == "regression":
                 _metrics = []

--- a/src/pytorch_tabular/models/base_model.py
+++ b/src/pytorch_tabular/models/base_model.py
@@ -259,7 +259,7 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
         """
         metrics = []
         for metric, metric_str, prob_inp, metric_params in zip(
-            self.metrics, self.hparams.metrics, self.hparams.metrics_prob_input, self.hparams.metrics_params
+            self.metrics, self.hparams.metrics, self.hparams.metrics_prob_inputs, self.hparams.metrics_params
         ):
             if self.hparams.task == "regression":
                 _metrics = []

--- a/src/pytorch_tabular/models/base_model.py
+++ b/src/pytorch_tabular/models/base_model.py
@@ -103,7 +103,7 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
                     config.metrics.append(metric.__name__)
                     config.metrics_params.append(vars(metric))
             if config.task == "classification":
-                config.metrics_prob_inputs = self.custom_metrics_prob_inputs
+                config.metrics_prob_input = self.custom_metrics_prob_inputs
         # Updating default metrics in config
         elif config.task == "classification":
             # Adding metric_params to config for classification task


### PR DESCRIPTION
The misnamed metrics_prob_inputs in the code results in no way to use probability calculations in the metrics under the classification task. 

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--239.org.readthedocs.build/en/239/

<!-- readthedocs-preview pytorch-tabular end -->