### PR TITLE
update tabnet to 4.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ omegaconf >=2.1.0
 torchmetrics >=0.10.0, <0.12.0
 tensorboard >2.2.0, !=2.5.0
 protobuf >=3.20.0, <4.24.0
-pytorch-tabnet ==4.0
+pytorch-tabnet ==4.1.0
 PyYAML >=5.4, <6.1.0
 # importlib-metadata <1,>=0.12
 matplotlib >3.1


### PR DESCRIPTION
tabnet 4.0 had a requirement of pytorch < 2.0. this requirement was the only thing (afaik) from pytorch_tabular supporting pytorch >= 2.0

this tiny PR just updates the tabnet requirement to 4.1.0 which allows for pytorch 2.0

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--271.org.readthedocs.build/en/271/

<!-- readthedocs-preview pytorch-tabular end -->