### PR TITLE
ci: add action to label PR conflicts

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,22 @@
+name: Label merge conflicts
+
+on:
+  push:
+    branches: ["main"]
+  pull_request_target:
+    types: ["synchronize", "reopened", "opened"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  triage-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@8c6faa8a252e35ba5e15703b3d747bf726cdb95c  # Oct 25, 2021
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 3
+          WAIT_MS: 5000


### PR DESCRIPTION
to work it correctly, you need also to create such label `has conflicts`
the reason is that otherwise, it takes a few more steps/click to find out why a PR with all green was not merged yet, and if you have bunch of PRs open you gain a much better overview

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--293.org.readthedocs.build/en/293/

<!-- readthedocs-preview pytorch-tabular end -->