### PR TITLE
tests: prune meaningless `assert True`

### DIFF
--- a/tests/test_autoint.py
+++ b/tests/test_autoint.py
@@ -32,53 +32,50 @@ def test_regression(
     attention_pooling,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "regression"}
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "regression"}
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config_params["deep_layers"] = deep_layers
-        model_config_params["batch_norm_continuous_input"] = batch_norm_continuous_input
-        model_config_params["attention_pooling"] = attention_pooling
-        model_config = AutoIntConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=3,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config_params["deep_layers"] = deep_layers
+    model_config_params["batch_norm_continuous_input"] = batch_norm_continuous_input
+    model_config_params["attention_pooling"] = attention_pooling
+    model_config = AutoIntConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=3,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        # print(result[0]["valid_loss"])
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    # print(result[0]["valid_loss"])
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -102,42 +99,39 @@ def test_classification(
     batch_norm_continuous_input,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "classification"}
-        model_config_params["deep_layers"] = deep_layers
-        model_config_params["batch_norm_continuous_input"] = batch_norm_continuous_input
-        model_config = AutoIntConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=3,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "classification"}
+    model_config_params["deep_layers"] = deep_layers
+    model_config_params["batch_norm_continuous_input"] = batch_norm_continuous_input
+    model_config = AutoIntConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=3,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        # print(result[0]["valid_loss"])
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    # print(result[0]["valid_loss"])
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 # @pytest.mark.parametrize(

--- a/tests/test_autoint.py
+++ b/tests/test_autoint.py
@@ -168,36 +168,33 @@ def test_classification(
 #     aug_task,
 # ):
 #     (train, test, target) = regression_data
-#     if len(continuous_cols) + len(categorical_cols) == 0:
-#         assert True
-#     else:
-#         data_config = DataConfig(
-#             target=target,
-#             continuous_cols=continuous_cols,
-#             categorical_cols=categorical_cols,
-#             continuous_feature_transform=continuous_feature_transform,
-#             normalize_continuous_features=normalize_continuous_features,
-#         )
-#         model_config_params = dict(task="ssl", ssl_task=ssl_task, aug_task=aug_task)
-#         model_config_params["deep_layers"] = deep_layers
-#         model_config_params["batch_norm_continuous_input"] = batch_norm_continuous_input
-#         model_config_params["attention_pooling"] = attention_pooling
-#         model_config = AutoIntConfig(**model_config_params)
-#         trainer_config = TrainerConfig(
-#             max_epochs=3,
-#             checkpoints=None,
-#             early_stopping=None,
-#             fast_dev_run=True,
-#         )
-#         optimizer_config = OptimizerConfig()
-
-#         tabular_model = TabularModel(
-#             data_config=data_config,
-#             model_config=model_config,
-#             optimizer_config=optimizer_config,
-#             trainer_config=trainer_config,
-#         )
-#         tabular_model.fit(train=train, test=test)
-
-#         result = tabular_model.evaluate(test)
-#         assert "test_mean_squared_error" in result[0].keys()
+#     data_config = DataConfig(
+#         target=target,
+#         continuous_cols=continuous_cols,
+#         categorical_cols=categorical_cols,
+#         continuous_feature_transform=continuous_feature_transform,
+#         normalize_continuous_features=normalize_continuous_features,
+#     )
+#     model_config_params = dict(task="ssl", ssl_task=ssl_task, aug_task=aug_task)
+#     model_config_params["deep_layers"] = deep_layers
+#     model_config_params["batch_norm_continuous_input"] = batch_norm_continuous_input
+#     model_config_params["attention_pooling"] = attention_pooling
+#     model_config = AutoIntConfig(**model_config_params)
+#     trainer_config = TrainerConfig(
+#         max_epochs=3,
+#         checkpoints=None,
+#         early_stopping=None,
+#         fast_dev_run=True,
+#     )
+#     optimizer_config = OptimizerConfig()
+#
+#     tabular_model = TabularModel(
+#         data_config=data_config,
+#         model_config=model_config,
+#         optimizer_config=optimizer_config,
+#         trainer_config=trainer_config,
+#     )
+#     tabular_model.fit(train=train, test=test)
+#
+#     result = tabular_model.evaluate(test)
+#     assert "test_mean_squared_error" in result[0].keys()

--- a/tests/test_categorical_embedding.py
+++ b/tests/test_categorical_embedding.py
@@ -64,64 +64,64 @@ def test_regression(
     (train, test, target) = regression_data
     (custom_metrics, custom_metrics_prob_input, custom_loss, custom_optimizer) = custom_args
     if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "regression"}
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+        return
+
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "regression"}
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        if custom_head_config is not None:
-            model_config_params["head"] = "LinearHead"
-            model_config_params["head_config"] = {"layers": custom_head_config}
-        model_config = CategoryEmbeddingModelConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=3,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    if custom_head_config is not None:
+        model_config_params["head"] = "LinearHead"
+        model_config_params["head_config"] = {"layers": custom_head_config}
+    model_config = CategoryEmbeddingModelConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=3,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(
-            train=train,
-            test=test,
-            metrics=custom_metrics,
-            metrics_prob_inputs=custom_metrics_prob_input,
-            target_transform=target_transform,
-            loss=custom_loss,
-            optimizer=custom_optimizer,
-            optimizer_params={},
-        )
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(
+        train=train,
+        test=test,
+        metrics=custom_metrics,
+        metrics_prob_inputs=custom_metrics_prob_input,
+        target_transform=target_transform,
+        loss=custom_loss,
+        optimizer=custom_optimizer,
+        optimizer_params={},
+    )
 
-        result = tabular_model.evaluate(test)
-        # print(result[0]["valid_loss"])
-        if custom_metrics is None:
-            assert "test_mean_squared_error" in result[0].keys()
-        else:
-            assert "test_fake_metric" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    # print(result[0]["valid_loss"])
+    if custom_metrics is None:
+        assert "test_mean_squared_error" in result[0].keys()
+    else:
+        assert "test_fake_metric" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -143,39 +143,39 @@ def test_classification(
 ):
     (train, test, target) = classification_data
     if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "classification"}
-        model_config = CategoryEmbeddingModelConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=3,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+        return
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "classification"}
+    model_config = CategoryEmbeddingModelConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=3,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        result = tabular_model.evaluate(test)
-        # print(result[0]["valid_loss"])
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
+
+    result = tabular_model.evaluate(test)
+    # print(result[0]["valid_loss"])
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 def test_embedding_transformer(regression_data):

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -53,54 +53,54 @@ def test_dataloader(
     (train, test, target) = regression_data
     train, valid = train_test_split(train, random_state=42)
     if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-            validation_split=validation_split,
-        )
-        model_config_params = {"task": "regression", "embedding_dims": embedding_dims}
-        model_config = CategoryEmbeddingModelConfig(**model_config_params)
-        trainer_config = TrainerConfig(max_epochs=1, checkpoints=None, early_stopping=None)
-        optimizer_config = OptimizerConfig()
+        return
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        config = tabular_model.config
-        datamodule = TabularDatamodule(
-            train=train,
-            validation=valid,
-            config=config,
-            test=test,
-            target_transform=target_transform,
-        )
-        datamodule.prepare_data()
-        datamodule.setup("fit")
-        inferred_config = datamodule.update_config(config)
-        if len(categorical_cols) > 0:
-            assert inferred_config.categorical_cardinality[0] == 5
-            if embedding_dims is None:
-                assert inferred_config.embedding_dims[0][-1] == 3
-            else:
-                assert inferred_config.embedding_dims[0][-1] == embedding_dims[0][-1]
-        if normalize_continuous_features and len(continuous_cols) > 0:
-            assert round(datamodule.train[config.continuous_cols[0]].mean()) == 0
-            assert round(datamodule.train[config.continuous_cols[0]].std()) == 1
-            # assert round(datamodule.validation[config.continuous_cols[0]].mean()) == 0
-            # assert round(datamodule.validation[config.continuous_cols[0]].std()) == 1
-        val_loader = datamodule.val_dataloader()
-        _val_loader = datamodule.prepare_inference_dataloader(valid)
-        chk_1 = next(iter(val_loader))["continuous"]
-        chk_2 = next(iter(_val_loader))["continuous"]
-        assert np.not_equal(chk_1, chk_2).sum().item() == 0
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+        validation_split=validation_split,
+    )
+    model_config_params = {"task": "regression", "embedding_dims": embedding_dims}
+    model_config = CategoryEmbeddingModelConfig(**model_config_params)
+    trainer_config = TrainerConfig(max_epochs=1, checkpoints=None, early_stopping=None)
+    optimizer_config = OptimizerConfig()
+
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    config = tabular_model.config
+    datamodule = TabularDatamodule(
+        train=train,
+        validation=valid,
+        config=config,
+        test=test,
+        target_transform=target_transform,
+    )
+    datamodule.prepare_data()
+    datamodule.setup("fit")
+    inferred_config = datamodule.update_config(config)
+    if len(categorical_cols) > 0:
+        assert inferred_config.categorical_cardinality[0] == 5
+        if embedding_dims is None:
+            assert inferred_config.embedding_dims[0][-1] == 3
+        else:
+            assert inferred_config.embedding_dims[0][-1] == embedding_dims[0][-1]
+    if normalize_continuous_features and len(continuous_cols) > 0:
+        assert round(datamodule.train[config.continuous_cols[0]].mean()) == 0
+        assert round(datamodule.train[config.continuous_cols[0]].std()) == 1
+        # assert round(datamodule.validation[config.continuous_cols[0]].mean()) == 0
+        # assert round(datamodule.validation[config.continuous_cols[0]].std()) == 1
+    val_loader = datamodule.val_dataloader()
+    _val_loader = datamodule.prepare_inference_dataloader(valid)
+    chk_1 = next(iter(val_loader))["continuous"]
+    chk_2 = next(iter(_val_loader))["continuous"]
+    assert np.not_equal(chk_1, chk_2).sum().item() == 0
 
 
 @pytest.mark.parametrize(
@@ -148,6 +148,5 @@ def test_date_encoding(timeseries_data, freq):
     elif freq == "S":
         try:
             datamodule.setup("fit")
-            assert False
         except RuntimeError:
-            assert True
+            pass

--- a/tests/test_ft_transformer.py
+++ b/tests/test_ft_transformer.py
@@ -37,53 +37,52 @@ def test_regression(
 ):
     (train, test, target) = regression_data
     if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "regression",
-            "input_embed_dim": 8,
-            "num_attn_blocks": 1,
-            "num_heads": 2,
-        }
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+        return
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "regression",
+        "input_embed_dim": 8,
+        "num_attn_blocks": 1,
+        "num_heads": 2,
+    }
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config = FTTransformerConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config = FTTransformerConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -103,44 +102,41 @@ def test_classification(
     normalize_continuous_features,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "classification",
-            "input_embed_dim": 8,
-            "num_attn_blocks": 1,
-            "num_heads": 2,
-        }
-        model_config = FTTransformerConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "classification",
+        "input_embed_dim": 8,
+        "num_attn_blocks": 1,
+        "num_heads": 2,
+    }
+    model_config = FTTransformerConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 def test_embedding_transformer(regression_data):

--- a/tests/test_gandalf.py
+++ b/tests/test_gandalf.py
@@ -37,49 +37,46 @@ def test_regression(
     target_range,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "regression", "gflu_stages": 1}
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "regression", "gflu_stages": 1}
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config = GANDALFConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config = GANDALFConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -99,39 +96,36 @@ def test_classification(
     normalize_continuous_features,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "classification", "gflu_stages": 1}
-        model_config = GANDALFConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "classification", "gflu_stages": 1}
+    model_config = GANDALFConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 # def test_embedding_transformer(regression_data):

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -37,54 +37,51 @@ def test_regression(
     target_range,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "regression",
-            "gflu_stages": 1,
-            "tree_depth": 1,
-            "num_trees": 2,
-        }
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "regression",
+        "gflu_stages": 1,
+        "tree_depth": 1,
+        "num_trees": 2,
+    }
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config = GatedAdditiveTreeEnsembleConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config = GatedAdditiveTreeEnsembleConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -104,44 +101,41 @@ def test_classification(
     normalize_continuous_features,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "classification",
-            "gflu_stages": 1,
-            "tree_depth": 1,
-            "num_trees": 2,
-        }
-        model_config = GatedAdditiveTreeEnsembleConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "classification",
+        "gflu_stages": 1,
+        "tree_depth": 1,
+        "num_trees": 2,
+    }
+    model_config = GatedAdditiveTreeEnsembleConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 # def test_embedding_transformer(regression_data):

--- a/tests/test_mdn.py
+++ b/tests/test_mdn.py
@@ -38,45 +38,42 @@ def test_regression(
     num_gaussian,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "regression"}
-        mdn_config = {"num_gaussian": num_gaussian}
-        model_config_params["head_config"] = mdn_config
-        model_config_params["backbone_config_class"] = variant
-        model_config_params["backbone_config_params"] = {"task": "backbone"}
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "regression"}
+    mdn_config = {"num_gaussian": num_gaussian}
+    model_config_params["head_config"] = mdn_config
+    model_config_params["backbone_config_class"] = variant
+    model_config_params["backbone_config_params"] = {"task": "backbone"}
 
-        model_config = MDNConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=3,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    model_config = MDNConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=3,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        # print(result[0]["valid_loss"])
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    # print(result[0]["valid_loss"])
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -99,36 +96,33 @@ def test_classification(
     num_gaussian,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "classification"}
-        mdn_config = {"num_gaussian": num_gaussian}
-        model_config_params["head_config"] = mdn_config
-        model_config_params["backbone_config_class"] = "CategoryEmbeddingMDNConfig"
-        model_config_params["backbone_config_params"] = {"task": "backbone"}
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "classification"}
+    mdn_config = {"num_gaussian": num_gaussian}
+    model_config_params["head_config"] = mdn_config
+    model_config_params["backbone_config_class"] = "CategoryEmbeddingMDNConfig"
+    model_config_params["backbone_config_params"] = {"task": "backbone"}
 
-        model_config = MDNConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=3,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
+    model_config = MDNConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=3,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
+    with pytest.raises(AssertionError):
+        tabular_model = TabularModel(
+            data_config=data_config,
+            model_config=model_config,
+            optimizer_config=optimizer_config,
+            trainer_config=trainer_config,
         )
-        optimizer_config = OptimizerConfig()
-        with pytest.raises(AssertionError):
-            tabular_model = TabularModel(
-                data_config=data_config,
-                model_config=model_config,
-                optimizer_config=optimizer_config,
-                trainer_config=trainer_config,
-            )
-            tabular_model.fit(train=train, test=test)
+        tabular_model.fit(train=train, test=test)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -38,54 +38,51 @@ def test_regression(
     target_range,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "regression",
-            "depth": 2,
-            "num_trees": 50,
-            "embed_categorical": embed_categorical,
-        }
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "regression",
+        "depth": 2,
+        "num_trees": 50,
+        "embed_categorical": embed_categorical,
+    }
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config = NodeConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config = NodeConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -107,44 +104,41 @@ def test_classification(
     normalize_continuous_features,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "classification",
-            "depth": 2,
-            "num_trees": 50,
-            "embed_categorical": embed_categorical,
-        }
-        model_config = NodeConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "classification",
+        "depth": 2,
+        "num_trees": 50,
+        "embed_categorical": embed_categorical,
+    }
+    model_config = NodeConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 def test_embedding_transformer(regression_data):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -58,90 +58,87 @@ def test_regression(
     ssl, finetune = train_test_split(train, random_state=42)
     ssl_train, ssl_val = train_test_split(ssl, random_state=42)
     finetune_train, finetune_val = train_test_split(finetune, random_state=42)
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-            handle_missing_values=False,
-            handle_unknown_categories=False,
-        )
-        encoder_config = CategoryEmbeddingModelConfig(
-            task="backbone",
-            layers="4096-2048-512",  # Number of nodes in each layer
-            activation="LeakyReLU",  # Activation between each layers
-        )
-        decoder_config = CategoryEmbeddingModelConfig(
-            task="backbone",
-            layers="512-2048-4096",  # Number of nodes in each layer
-            activation="LeakyReLU",  # Activation between each layers
-        )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+        handle_missing_values=False,
+        handle_unknown_categories=False,
+    )
+    encoder_config = CategoryEmbeddingModelConfig(
+        task="backbone",
+        layers="4096-2048-512",  # Number of nodes in each layer
+        activation="LeakyReLU",  # Activation between each layers
+    )
+    decoder_config = CategoryEmbeddingModelConfig(
+        task="backbone",
+        layers="512-2048-4096",  # Number of nodes in each layer
+        activation="LeakyReLU",  # Activation between each layers
+    )
 
-        model_config_params = {
-            "encoder_config": encoder_config,
-            "decoder_config": decoder_config,
-        }
-        model_config = DenoisingAutoEncoderConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    model_config_params = {
+        "encoder_config": encoder_config,
+        "decoder_config": decoder_config,
+    }
+    model_config = DenoisingAutoEncoderConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.pretrain(train=ssl_train, validation=ssl_val)
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.pretrain(train=ssl_train, validation=ssl_val)
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-        else:
-            _target_range = None
-        finetune_model = tabular_model.create_finetune_model(
-            task="regression",
-            head="LinearHead",
-            head_config={
-                "layers": "64-32-16",
-                "activation": "LeakyReLU",
-            },
-            trainer_config=trainer_config,
-            optimizer_config=optimizer_config,
-            target_range=_target_range,
-            loss=custom_loss,
-            metrics=custom_metrics,
-            metrics_params=[{}],
-            metrics_prob_input=metrics_prob_input,
-            optimizer=custom_optimizer,
-        )
-        finetune_model.finetune(
-            train=finetune_train,
-            validation=finetune_val,
-            freeze_backbone=freeze_backbone,
-            target_transform=target_transform,
-        )
-        result = finetune_model.evaluate(test)
-        if custom_metrics is None:
-            assert "test_mean_squared_error" in result[0].keys()
-        else:
-            assert "test_fake_metric" in result[0].keys()
-        pred_df = finetune_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+            )
+    else:
+        _target_range = None
+    finetune_model = tabular_model.create_finetune_model(
+        task="regression",
+        head="LinearHead",
+        head_config={
+            "layers": "64-32-16",
+            "activation": "LeakyReLU",
+        },
+        trainer_config=trainer_config,
+        optimizer_config=optimizer_config,
+        target_range=_target_range,
+        loss=custom_loss,
+        metrics=custom_metrics,
+        metrics_params=[{}],
+        metrics_prob_input=metrics_prob_input,
+        optimizer=custom_optimizer,
+    )
+    finetune_model.finetune(
+        train=finetune_train,
+        validation=finetune_val,
+        freeze_backbone=freeze_backbone,
+        target_transform=target_transform,
+    )
+    result = finetune_model.evaluate(test)
+    if custom_metrics is None:
+        assert "test_mean_squared_error" in result[0].keys()
+    else:
+        assert "test_fake_metric" in result[0].keys()
+    pred_df = finetune_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -166,65 +163,62 @@ def test_classification(
     ssl, finetune = train_test_split(train, random_state=42)
     ssl_train, ssl_val = train_test_split(ssl, random_state=42)
     finetune_train, finetune_val = train_test_split(finetune, random_state=42)
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-            handle_missing_values=False,
-            handle_unknown_categories=False,
-        )
-        encoder_config = CategoryEmbeddingModelConfig(
-            task="backbone",
-            layers="4096-2048-512",  # Number of nodes in each layer
-            activation="LeakyReLU",  # Activation between each layers
-        )
-        decoder_config = CategoryEmbeddingModelConfig(
-            task="backbone",
-            layers="512-2048-4096",  # Number of nodes in each layer
-            activation="LeakyReLU",  # Activation between each layers
-        )
-        model_config_params = {
-            "encoder_config": encoder_config,
-            "decoder_config": decoder_config,
-        }
-        model_config = DenoisingAutoEncoderConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+        handle_missing_values=False,
+        handle_unknown_categories=False,
+    )
+    encoder_config = CategoryEmbeddingModelConfig(
+        task="backbone",
+        layers="4096-2048-512",  # Number of nodes in each layer
+        activation="LeakyReLU",  # Activation between each layers
+    )
+    decoder_config = CategoryEmbeddingModelConfig(
+        task="backbone",
+        layers="512-2048-4096",  # Number of nodes in each layer
+        activation="LeakyReLU",  # Activation between each layers
+    )
+    model_config_params = {
+        "encoder_config": encoder_config,
+        "decoder_config": decoder_config,
+    }
+    model_config = DenoisingAutoEncoderConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.pretrain(train=ssl_train, validation=ssl_val)
-        finetune_model = tabular_model.create_finetune_model(
-            task="classification",
-            head="LinearHead",
-            head_config={
-                "layers": "64-32-16",
-                "activation": "LeakyReLU",
-            },
-            trainer_config=trainer_config,
-            optimizer_config=optimizer_config,
-        )
-        finetune_model.finetune(
-            train=finetune_train,
-            validation=finetune_val,
-            freeze_backbone=freeze_backbone,
-        )
-        result = finetune_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = finetune_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.pretrain(train=ssl_train, validation=ssl_val)
+    finetune_model = tabular_model.create_finetune_model(
+        task="classification",
+        head="LinearHead",
+        head_config={
+            "layers": "64-32-16",
+            "activation": "LeakyReLU",
+        },
+        trainer_config=trainer_config,
+        optimizer_config=optimizer_config,
+    )
+    finetune_model.finetune(
+        train=finetune_train,
+        validation=finetune_val,
+        freeze_backbone=freeze_backbone,
+    )
+    result = finetune_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = finetune_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]

--- a/tests/test_tabnet.py
+++ b/tests/test_tabnet.py
@@ -35,49 +35,46 @@ def test_regression(
     target_range,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "regression"}
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "regression"}
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config = TabNetModelConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config = TabNetModelConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -95,36 +92,33 @@ def test_classification(
     normalize_continuous_features,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {"task": "classification"}
-        model_config = TabNetModelConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {"task": "classification"}
+    model_config = TabNetModelConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]

--- a/tests/test_tabtransformer.py
+++ b/tests/test_tabtransformer.py
@@ -36,54 +36,51 @@ def test_regression(
     target_range,
 ):
     (train, test, target) = regression_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target + ["MedInc"] if multi_target else target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "regression",
-            "input_embed_dim": 8,
-            "num_attn_blocks": 1,
-            "num_heads": 2,
-        }
-        if target_range:
-            _target_range = []
-            for target in data_config.target:
-                _target_range.append(
-                    (
-                        float(train[target].min()),
-                        float(train[target].max()),
-                    )
+    data_config = DataConfig(
+        target=target + ["MedInc"] if multi_target else target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "regression",
+        "input_embed_dim": 8,
+        "num_attn_blocks": 1,
+        "num_heads": 2,
+    }
+    if target_range:
+        _target_range = []
+        for target in data_config.target:
+            _target_range.append(
+                (
+                    float(train[target].min()),
+                    float(train[target].max()),
                 )
-            model_config_params["target_range"] = _target_range
-        model_config = TabTransformerConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+            )
+        model_config_params["target_range"] = _target_range
+    model_config = TabTransformerConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_mean_squared_error" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_mean_squared_error" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -103,44 +100,41 @@ def test_classification(
     normalize_continuous_features,
 ):
     (train, test, target) = classification_data
-    if len(continuous_cols) + len(categorical_cols) == 0:
-        assert True
-    else:
-        data_config = DataConfig(
-            target=target,
-            continuous_cols=continuous_cols,
-            categorical_cols=categorical_cols,
-            continuous_feature_transform=continuous_feature_transform,
-            normalize_continuous_features=normalize_continuous_features,
-        )
-        model_config_params = {
-            "task": "classification",
-            "input_embed_dim": 8,
-            "num_attn_blocks": 1,
-            "num_heads": 2,
-        }
-        model_config = TabTransformerConfig(**model_config_params)
-        trainer_config = TrainerConfig(
-            max_epochs=1,
-            checkpoints=None,
-            early_stopping=None,
-            accelerator="cpu",
-            fast_dev_run=True,
-        )
-        optimizer_config = OptimizerConfig()
+    data_config = DataConfig(
+        target=target,
+        continuous_cols=continuous_cols,
+        categorical_cols=categorical_cols,
+        continuous_feature_transform=continuous_feature_transform,
+        normalize_continuous_features=normalize_continuous_features,
+    )
+    model_config_params = {
+        "task": "classification",
+        "input_embed_dim": 8,
+        "num_attn_blocks": 1,
+        "num_heads": 2,
+    }
+    model_config = TabTransformerConfig(**model_config_params)
+    trainer_config = TrainerConfig(
+        max_epochs=1,
+        checkpoints=None,
+        early_stopping=None,
+        accelerator="cpu",
+        fast_dev_run=True,
+    )
+    optimizer_config = OptimizerConfig()
 
-        tabular_model = TabularModel(
-            data_config=data_config,
-            model_config=model_config,
-            optimizer_config=optimizer_config,
-            trainer_config=trainer_config,
-        )
-        tabular_model.fit(train=train, test=test)
+    tabular_model = TabularModel(
+        data_config=data_config,
+        model_config=model_config,
+        optimizer_config=optimizer_config,
+        trainer_config=trainer_config,
+    )
+    tabular_model.fit(train=train, test=test)
 
-        result = tabular_model.evaluate(test)
-        assert "test_accuracy" in result[0].keys()
-        pred_df = tabular_model.predict(test)
-        assert pred_df.shape[0] == test.shape[0]
+    result = tabular_model.evaluate(test)
+    assert "test_accuracy" in result[0].keys()
+    pred_df = tabular_model.predict(test)
+    assert pred_df.shape[0] == test.shape[0]
 
 
 def test_embedding_transformer(regression_data):


### PR DESCRIPTION
the if/else fork is quite confusing so replacing it with simple `retun`
moreover, in most cases, there is not such configuration in test parametrization so it can be dropped completely

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--294.org.readthedocs.build/en/294/

<!-- readthedocs-preview pytorch-tabular end -->