### PR TITLE
refactor: use seed and using or

### DIFF
--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -520,7 +520,7 @@ class TabularDatamodule(pl.LightningDataModule):
         )
         return DataLoader(
             dataset,
-            batch_size if batch_size is not None else self.batch_size,
+            batch_size or self.batch_size,
             shuffle=True if self.train_sampler is None else False,
             num_workers=self.config.num_workers,
             sampler=self.train_sampler,
@@ -546,7 +546,7 @@ class TabularDatamodule(pl.LightningDataModule):
         )
         return DataLoader(
             dataset,
-            batch_size if batch_size is not None else self.batch_size,
+            batch_size or self.batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
             pin_memory=self.config.pin_memory,
@@ -572,7 +572,7 @@ class TabularDatamodule(pl.LightningDataModule):
             )
             return DataLoader(
                 dataset,
-                batch_size if batch_size is not None else self.batch_size,
+                batch_size or self.batch_size,
                 shuffle=False,
                 num_workers=self.config.num_workers,
                 pin_memory=self.config.pin_memory,
@@ -611,7 +611,7 @@ class TabularDatamodule(pl.LightningDataModule):
         )
         return DataLoader(
             dataset,
-            batch_size if batch_size is not None else self.batch_size,
+            batch_size or self.batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
         )

--- a/src/pytorch_tabular/tabular_model.py
+++ b/src/pytorch_tabular/tabular_model.py
@@ -667,8 +667,9 @@ class TabularModel:
             assert len(metrics) == len(
                 metrics_prob_inputs
             ), "The length of `metrics` and `metrics_prob_inputs` should be equal"
-        seed = seed if seed is not None else self.config.seed
-        seed_everything(seed)
+        seed = seed or self.config.seed
+        if seed:
+            seed_everything(seed)
         if datamodule is None:
             datamodule = self.prepare_dataloader(train, validation, test, train_sampler, target_transform, seed)
         else:
@@ -738,8 +739,9 @@ class TabularModel:
         assert (
             self.config.task == "ssl"
         ), f"`pretrain` is not valid for {self.config.task} task. Please use `fit` instead."
-        seed = seed if seed is not None else self.config.seed
-        seed_everything(seed)
+        seed = seed or self.config.seed
+        if seed:
+            seed_everything(seed)
         if datamodule is None:
             datamodule = self.prepare_dataloader(
                 train,
@@ -973,8 +975,9 @@ class TabularModel:
         assert (
             self._is_finetune_model
         ), "finetune() can only be called on a finetune model created using `TabularModel.create_finetune_model()`"
-        seed = seed if seed is not None else self.config.seed
-        seed_everything(seed)
+        seed = seed or self.config.seed
+        if seed:
+            seed_everything(seed)
         if datamodule is None:
             target_transform = self._check_and_set_target_transform(target_transform)
             self.datamodule._set_target_transform(target_transform)

--- a/src/pytorch_tabular/utils/nn_utils.py
+++ b/src/pytorch_tabular/utils/nn_utils.py
@@ -82,7 +82,7 @@ def to_one_hot(y, depth=None):
         depth (int):  the size of the one hot dimension
     """
     y_flat = y.to(torch.int64).view(-1, 1)
-    depth = depth if depth is not None else int(torch.max(y_flat)) + 1
+    depth = depth or int(torch.max(y_flat)) + 1
     y_one_hot = torch.zeros(y_flat.size()[0], depth, device=y.device).scatter_(1, y_flat, 1)
     y_one_hot = y_one_hot.view(*(tuple(y.shape) + (-1,)))
     return y_one_hot


### PR DESCRIPTION
there is some strange bug https://github.com/Lightning-AI/lightning/issues/18444#issuecomment-1807007492 with a torch, so this will allow us to bypass it
 and also simplify too long `<var> if <var> is is not None else <var2>`

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--296.org.readthedocs.build/en/296/

<!-- readthedocs-preview pytorch-tabular end -->