### PR TITLE
fixed bug for ssl with binary dtype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ examples/test_save/
 # Ruff
 .ruff_cache/
 tests/.datasets/
+test.py

--- a/src/pytorch_tabular/ssl_models/dae/dae.py
+++ b/src/pytorch_tabular/ssl_models/dae/dae.py
@@ -189,9 +189,12 @@ class DenoisingAutoEncoderModel(SSLBaseModel):
                 loss = 0
                 for i in range(out.original.size(-1)):
                     loss += self.losses[type_](out.reconstructed[i], out.original[:, i])
-                loss *= getattr(self.loss_weights, type_)
+            elif type_ == "binary":
+                # Casting output to float for BCEWithLogitsLoss
+                loss = self.losses[type_](out.reconstructed, out.original.float())
             else:
-                loss = self.losses[type_](out.reconstructed, out.original) * getattr(self.loss_weights, type_)
+                loss = self.losses[type_](out.reconstructed, out.original)
+            loss *= getattr(self.loss_weights, type_)
             self.log(
                 f"{tag}_{type_}_loss",
                 loss.item(),


### PR DESCRIPTION
Fixes #304 by making sure the bcewithcrossentropy is called with right data types

<!-- readthedocs-preview pytorch-tabular start -->
----
:books: Documentation preview :books:: https://pytorch-tabular--315.org.readthedocs.build/en/315/

<!-- readthedocs-preview pytorch-tabular end -->