### PR TITLE
bugfix: update embedding_dims if new features are added

### DIFF
--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -359,6 +359,7 @@ class TabularDatamodule(pl.LightningDataModule):
             self.config.categorical_dim = (
                 len(self.config.categorical_cols) if self.config.categorical_cols is not None else 0
             )
+            self._inferred_config = self._update_config(self.config)
         # Encoding Categorical Columns
         if len(self.config.categorical_cols) > 0:
             data = self._encode_categorical_columns(data, stage)


### PR DESCRIPTION
if new features are added in `tabular_datamodule.preprocess_data` we need to update `embedding_dims` again to account for the new features

nb @manujosephv: calling `_update_config` was the simplest way i could see to do this but let me know if you'd prefer something else

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--358.org.readthedocs.build/en/358/

<!-- readthedocs-preview pytorch-tabular end -->