### PR TITLE
Fix syntax error in experiment_tracking.md log_target

### DIFF
--- a/docs/experiment_tracking.md
+++ b/docs/experiment_tracking.md
@@ -14,7 +14,7 @@ Tensorboard logging is barebones. PyTorch Tabular just logs the losses and metri
 ### Usage Example
 
 ```python
-experiment_config = ExperimentConfig(project_name="MyAwesomeProject", run_name="my_cool_new_model", log_target=")
+experiment_config = ExperimentConfig(project_name="MyAwesomeProject", run_name="my_cool_new_model", log_target="wandb")
 ```
 
 ## Advanced Usage


### PR DESCRIPTION
Fix syntax error in experiment_tracking.md log_target



<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--382.org.readthedocs.build/en/382/

<!-- readthedocs-preview pytorch-tabular end -->