### PR TITLE
Fix attr that was not been changed

### DIFF
--- a/src/pytorch_tabular/tabular_model_tuner.py
+++ b/src/pytorch_tabular/tabular_model_tuner.py
@@ -111,7 +111,7 @@ class TabularModelTuner:
                 raise ValueError(f"{param} is not a valid parameter for {str(config)}")
         elif isinstance(config, ModelConfig):
             if hasattr(config, param):
-                config.param = value
+                setattr(config, param, value)
             else:
                 raise ValueError(f"{param} is not a valid parameter for {str(config)}")
 


### PR DESCRIPTION
The Tuner is not changing the hyperparameters, like we can see in the following images. I changed the code to print the configs:
![screenshot_2](https://github.com/manujosephv/pytorch_tabular/assets/130674366/8df36290-f7df-45f1-b997-1bd659a6b089)
![image](https://github.com/manujosephv/pytorch_tabular/assets/130674366/078f631c-9348-4d74-8dba-50b9e0253ef9)

Was to change "layers" to "1-1-1", but before and after the current code is not changing the values. With the new code, it is changing. I do not know how it is not raising an exception because it is trying to change an attribute that does not exist.
![image](https://github.com/manujosephv/pytorch_tabular/assets/130674366/1c6b38f4-6a9f-4c29-af1b-9f39da59a663)


<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--384.org.readthedocs.build/en/384/

<!-- readthedocs-preview pytorch-tabular end -->