### PR TITLE
Fix KeyError nn.activation in Tab Transformer and FT Transformer

### DIFF
--- a/src/pytorch_tabular/models/common/layers/transformers.py
+++ b/src/pytorch_tabular/models/common/layers/transformers.py
@@ -111,12 +111,12 @@ class TransformerEncoderBlock(nn.Module):
                 d_ff=input_embed_dim * ff_hidden_multiplier,
                 dropout=ff_dropout,
             )
-        except AttributeError:
+        except (AttributeError, KeyError):
             self.pos_wise_ff = PositionWiseFeedForward(
                 d_model=input_embed_dim,
                 d_ff=input_embed_dim * ff_hidden_multiplier,
                 dropout=ff_dropout,
-                activation=getattr(nn, self.hparams.ff_activation),
+                activation=getattr(nn, ff_activation)()
             )
         self.attn_add_norm = AddNorm(input_embed_dim, add_norm_dropout)
         self.ff_add_norm = AddNorm(input_embed_dim, add_norm_dropout)


### PR DESCRIPTION
Tab Transformer and FT Transformer have some custom activations that works normally and were also supposed to support PyTorch activations, but when used like "ReLU" it returned the following error:
```
model_config_tab_transformer = pytorch_tabular.models.TabTransformerConfig(
    task='classification',
    transformer_activation='ReLU'
)
```

![image](https://github.com/manujosephv/pytorch_tabular/assets/130674366/a33b76dc-f538-4286-998f-889235b4da35)

This is happening because the exception is not "AttributeError" but "KeyError".