### PR TITLE
Protection for MDN Head misuse

### DIFF
--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -922,6 +922,8 @@ class ModelConfig:
 
         if self.task != "backbone":
             assert self.head in dir(heads.blocks), f"{self.head} is not a valid head"
+            assert self.head != "MixtureDensityHead", "MixtureDensityHead is not supported as a head. Please see "
+            "Probabilistic Regression with MDN How-to-Guide in documentation for the right usage."
             _head_callable = getattr(heads.blocks, self.head)
             ideal_head_config = _head_callable._config_template
             invalid_keys = set(self.head_config.keys()) - set(ideal_head_config.__dict__.keys())

--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -922,8 +922,10 @@ class ModelConfig:
 
         if self.task != "backbone":
             assert self.head in dir(heads.blocks), f"{self.head} is not a valid head"
-            assert self.head != "MixtureDensityHead", "MixtureDensityHead is not supported as a head. Please see "
-            "Probabilistic Regression with MDN How-to-Guide in documentation for the right usage."
+            if hasattr(self, "_config_name") and self._config_name != "MDNConfig":
+                assert self.head != "MixtureDensityHead", "MixtureDensityHead is not supported as a head for regular "
+                "models. Use `MDNConfig` instead. Please see Probabilistic Regression with MDN How-to-Guide in "
+                "documentation for the right usage."
             _head_callable = getattr(heads.blocks, self.head)
             ideal_head_config = _head_callable._config_template
             invalid_keys = set(self.head_config.keys()) - set(ideal_head_config.__dict__.keys())


### PR DESCRIPTION
#424 raised an issue regarding MDN heads. But the usages wasn't as intended. So adding protection against such usage

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--448.org.readthedocs.build/en/448/

<!-- readthedocs-preview pytorch-tabular end -->