### PR TITLE
Remove restriction for using missing and unknown category in SSL models

### DIFF
--- a/src/pytorch_tabular/tabular_model.py
+++ b/src/pytorch_tabular/tabular_model.py
@@ -2,6 +2,7 @@
 # Author: Manu Joseph <manujoseph@gmail.com>
 # For license information, see LICENSE.TXT
 """Tabular Model."""
+
 import inspect
 import os
 import warnings
@@ -21,9 +22,7 @@ from omegaconf.dictconfig import DictConfig
 from pandas import DataFrame
 from pytorch_lightning import seed_everything
 from pytorch_lightning.callbacks import RichProgressBar
-from pytorch_lightning.callbacks.gradient_accumulation_scheduler import (
-    GradientAccumulationScheduler,
-)
+from pytorch_lightning.callbacks.gradient_accumulation_scheduler import GradientAccumulationScheduler
 from pytorch_lightning.tuner.tuning import Tuner
 from pytorch_lightning.utilities.model_summary import summarize
 from rich import print as rich_print
@@ -42,11 +41,7 @@ from pytorch_tabular.config import (
 )
 from pytorch_tabular.config.config import InferredConfig
 from pytorch_tabular.models.base_model import BaseModel, _CaptumModel, _GenericModel
-from pytorch_tabular.models.common.layers.embeddings import (
-    Embedding1dLayer,
-    Embedding2dLayer,
-    PreEncoded1dLayer,
-)
+from pytorch_tabular.models.common.layers.embeddings import Embedding1dLayer, Embedding2dLayer, PreEncoded1dLayer
 from pytorch_tabular.tabular_datamodule import TabularDatamodule
 from pytorch_tabular.utils import (
     OOMException,
@@ -231,13 +226,6 @@ class TabularModel:
                         " two(min,max). The length of the list should be equal to hte"
                         " length of target columns"
                     )
-        if self.config.task == "ssl":
-            assert not self.config.handle_unknown_categories, (
-                "SSL only supports handle_unknown_categories=False. Please set this" " in your DataConfig"
-            )
-            assert not self.config.handle_missing_values, (
-                "SSL only supports handle_missing_values=False. Please set this in" " your DataConfig"
-            )
 
     def _read_parse_config(self, config, cls):
         if isinstance(config, str):


### PR DESCRIPTION
I've simply removed the `if` block that prevented setting these to true in config for SSL models. I'm open to adding to documentation or test cases if needed. 

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--470.org.readthedocs.build/en/470/

<!-- readthedocs-preview pytorch-tabular end -->