### PR TITLE
freeze `numpy <2.0` & fix ci+docs

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -24,7 +24,7 @@ jobs:
 
             - name: Create package 📦
               run: |
-                  pip install "twine==4.0.2" setuptools wheel
+                  pip install "twine==5.1.1" setuptools wheel
                   python setup.py sdist bdist_wheel
                   ls -lh dist/
                   twine check dist/*

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 torch >=1.11.0
-numpy >1.20.0
+numpy >1.20.0, <2.0
 pandas >=1.1.5
 scikit-learn >=1.3.0
 pytorch-lightning >=2.0.0, <2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,10 @@
 wget
 bump2version ==1.0.1
 # coverage >=4.5.4
-mkdocs-material >=9.1.0, <9.6.0
+mkdocs-material ==9.5.*
 ipython[notebook] >8.0, <9.0
-mkdocstrings[python] >=0.23.0, <0.24.0
-mknotebooks >=0.8.0, <0.9.0
+mkdocstrings[python] ==0.26.*
+mknotebooks ==0.8.*
 pytest >=5.3.2
 pytest-runner >=5.1
 torch_optimizer


### PR DESCRIPTION
resolving some compatibility issues:
`AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.`
coming from third-party dependencies

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--482.org.readthedocs.build/en/482/

<!-- readthedocs-preview pytorch-tabular end -->