### PR TITLE
Add dataloader_kwargs support in DataConfig

### DIFF
--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -95,7 +95,9 @@ class DataConfig:
 
         handle_missing_values (bool): Whether to handle missing values in categorical columns as
                 unknown
-
+                
+        dataloader_kwargs (Dict[str, Any]): Additional kwargs to be passed to PyTorch DataLoader. See
+                https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader
     """
 
     target: Optional[List[str]] = field(
@@ -174,6 +176,11 @@ class DataConfig:
     handle_missing_values: bool = field(
         default=True,
         metadata={"help": "Whether or not to handle missing values in categorical columns as unknown"},
+    )
+    
+    dataloader_kwargs: Dict[str, Any] = field(
+        default_factory=dict,
+        metadata={"help": "Additional kwargs to be passed to PyTorch DataLoader."},
     )
 
     def __post_init__(self):

--- a/src/pytorch_tabular/config/config.py
+++ b/src/pytorch_tabular/config/config.py
@@ -95,9 +95,10 @@ class DataConfig:
 
         handle_missing_values (bool): Whether to handle missing values in categorical columns as
                 unknown
-                
+
         dataloader_kwargs (Dict[str, Any]): Additional kwargs to be passed to PyTorch DataLoader. See
                 https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader
+
     """
 
     target: Optional[List[str]] = field(
@@ -177,7 +178,7 @@ class DataConfig:
         default=True,
         metadata={"help": "Whether or not to handle missing values in categorical columns as unknown"},
     )
-    
+
     dataloader_kwargs: Dict[str, Any] = field(
         default_factory=dict,
         metadata={"help": "Additional kwargs to be passed to PyTorch DataLoader."},

--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -805,7 +805,7 @@ class TabularDatamodule(pl.LightningDataModule):
             num_workers=self.config.num_workers,
             sampler=self.train_sampler,
             pin_memory=self.config.pin_memory,
-            **self.config.dataloader_kwargs
+            **self.config.dataloader_kwargs,
         )
 
     def val_dataloader(self, batch_size: Optional[int] = None) -> DataLoader:
@@ -824,7 +824,7 @@ class TabularDatamodule(pl.LightningDataModule):
             shuffle=False,
             num_workers=self.config.num_workers,
             pin_memory=self.config.pin_memory,
-            **self.config.dataloader_kwargs
+            **self.config.dataloader_kwargs,
         )
 
     def _prepare_inference_data(self, df: DataFrame) -> DataFrame:
@@ -867,7 +867,7 @@ class TabularDatamodule(pl.LightningDataModule):
             batch_size or self.batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
-            **self.config.dataloader_kwargs
+            **self.config.dataloader_kwargs,
         )
 
     def save_dataloader(self, path: Union[str, Path]) -> None:

--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -805,6 +805,7 @@ class TabularDatamodule(pl.LightningDataModule):
             num_workers=self.config.num_workers,
             sampler=self.train_sampler,
             pin_memory=self.config.pin_memory,
+            **self.config.dataloader_kwargs
         )
 
     def val_dataloader(self, batch_size: Optional[int] = None) -> DataLoader:
@@ -823,6 +824,7 @@ class TabularDatamodule(pl.LightningDataModule):
             shuffle=False,
             num_workers=self.config.num_workers,
             pin_memory=self.config.pin_memory,
+            **self.config.dataloader_kwargs
         )
 
     def _prepare_inference_data(self, df: DataFrame) -> DataFrame:
@@ -865,6 +867,7 @@ class TabularDatamodule(pl.LightningDataModule):
             batch_size or self.batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
+            **self.config.dataloader_kwargs
         )
 
     def save_dataloader(self, path: Union[str, Path]) -> None:


### PR DESCRIPTION
**Modified Components:**
- `train_loader`, `val_loader`, and `prepare_inference_dataloader` in `src/pytorch_tabular/tabular_datamodule.py`
- `DataConfig` in `src/pytorch_tabular/config/config.py`

**Enhancement:**
- Added support for passing **kwargs to DataLoader for greater flexibility and customizability.

**Fixes Issue:**
- Closes #411.


<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--492.org.readthedocs.build/en/492/

<!-- readthedocs-preview pytorch-tabular end -->