### PR TITLE
chore(ci): setting concurrency

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,8 +6,8 @@ on:
     pull_request: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
     pytest:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,13 @@
 name: Testing
 
-on: [push, pull_request]
+on:
+    push:
+        branches: [main]
+    pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
     pytest:


### PR DESCRIPTION
This reduces the number of jobs per PR as it does not duplicate them and also cancels all outdated jobs per PR... as you can see right now the CI is completely sunken with just five open PRs

cc: @manujosephv 

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--524.org.readthedocs.build/en/524/

<!-- readthedocs-preview pytorch-tabular end -->