### PR TITLE
Make tensor dtypes `np.float32` for MPS devices

### DIFF
--- a/src/pytorch_tabular/ssl_models/common/noise_generators.py
+++ b/src/pytorch_tabular/ssl_models/common/noise_generators.py
@@ -18,7 +18,7 @@ class SwapNoiseCorrupter(nn.Module):
 
     def __init__(self, probas):
         super().__init__()
-        self.probas = torch.from_numpy(np.array(probas))
+        self.probas = torch.from_numpy(np.array(probas, dtype=np.float32))
 
     def forward(self, x):
         should_swap = torch.bernoulli(self.probas.to(x.device) * torch.ones(x.shape).to(x.device))

--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -67,7 +67,7 @@ class TabularDataset(Dataset):
             if isinstance(target, str):
                 self.y = self.y.reshape(-1, 1)  # .astype(np.int64)
         else:
-            self.y = np.zeros((self.n, 1))  # .astype(np.int64)
+            self.y = np.zeros((self.n, 1), dtype=np.float32)  # .astype(np.int64)
 
         if task == "classification":
             self.y = self.y.astype(np.int64)
@@ -502,7 +502,7 @@ class TabularDatamodule(pl.LightningDataModule):
 
     def split_train_val(self, train):
         logger.debug(
-            "No validation data provided." f" Using {self.config.validation_split*100}% of train data as validation"
+            f"No validation data provided. Using {self.config.validation_split * 100}% of train data as validation"
         )
         val_idx = train.sample(
             int(self.config.validation_split * len(train)),
@@ -753,18 +753,16 @@ class TabularDatamodule(pl.LightningDataModule):
             try:
                 dataset = getattr(self, f"_{tag}_dataset")
             except AttributeError:
-                raise AttributeError(
-                    f"{tag}_dataset not found in memory. Please provide the data for" f" {tag} dataloader"
-                )
+                raise AttributeError(f"{tag}_dataset not found in memory. Please provide the data for {tag} dataloader")
         elif self.cache_mode is self.CACHE_MODES.DISK:
             try:
                 dataset = torch.load(self.cache_dir / f"{tag}_dataset")
             except FileNotFoundError:
                 raise FileNotFoundError(
-                    f"{tag}_dataset not found in {self.cache_dir}. Please provide the" f" data for {tag} dataloader"
+                    f"{tag}_dataset not found in {self.cache_dir}. Please provide the data for {tag} dataloader"
                 )
         elif self.cache_mode is self.CACHE_MODES.INFERENCE:
-            raise RuntimeError("Cannot load dataset in inference mode. Use" " `prepare_inference_dataloader` instead")
+            raise RuntimeError("Cannot load dataset in inference mode. Use `prepare_inference_dataloader` instead")
         else:
             raise ValueError(f"{self.cache_mode} is not a valid cache mode")
         return dataset


### PR DESCRIPTION
numpy defaults to numpy.float64 when they should be numpy.float32

This caused training to fail on MPS devices but it works on my M1 with this.

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--540.org.readthedocs.build/en/540/

<!-- readthedocs-preview pytorch-tabular end -->