### PR TITLE
Torch load issue fix with pytorch 2.6

### DIFF
--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -758,7 +758,7 @@ class TabularDatamodule(pl.LightningDataModule):
                 )
         elif self.cache_mode is self.CACHE_MODES.DISK:
             try:
-                dataset = torch.load(self.cache_dir / f"{tag}_dataset")
+                dataset = torch.load(self.cache_dir / f"{tag}_dataset", weights_only=False)
             except FileNotFoundError:
                 raise FileNotFoundError(
                     f"{tag}_dataset not found in {self.cache_dir}. Please provide the" f" data for {tag} dataloader"

--- a/src/pytorch_tabular/utils/python_utils.py
+++ b/src/pytorch_tabular/utils/python_utils.py
@@ -74,7 +74,7 @@ def pl_load(
     """
     if not isinstance(path_or_url, (str, Path)):
         # any sort of BytesIO or similar
-        return torch.load(path_or_url, map_location=map_location)
+        return torch.load(path_or_url, map_location=map_location, weights_only=False)
     if str(path_or_url).startswith("http"):
         return torch.hub.load_state_dict_from_url(
             str(path_or_url),
@@ -82,7 +82,7 @@ def pl_load(
         )
     fs = get_filesystem(path_or_url)
     with fs.open(path_or_url, "rb") as f:
-        return torch.load(f, map_location=map_location)
+        return torch.load(f, map_location=map_location, weights_only=False)
 
 
 def check_numpy(x):


### PR DESCRIPTION
Pytorch 2.6 updated the torch.load function with "weights_only = True" as default. 
This caused an issue with the library making any load process crash. This also caused the tests to fail for other PRs #540 and even other bot PRs, #536, #537. 

I set for all torch.load functions to be "weight_only = False" instead of the default True to fix this issue. 

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--543.org.readthedocs.build/en/543/

<!-- readthedocs-preview pytorch-tabular end -->