### PR TITLE
minor bug fix

### DIFF
--- a/src/pytorch_tabular/tabular_model_tuner.py
+++ b/src/pytorch_tabular/tabular_model_tuner.py
@@ -409,7 +409,7 @@ class TabularModelTuner:
                     params.update({"trial_id": i})
                     trials.append(params)
                     if verbose:
-                        logger.info(f"Trial {i+1}/{n_trials}: {params} | Score: {params[metric]}")
+                        logger.info(f"Trial {i+1}/{n_trials}: {params} | Score: {params[metric_str]}")
 
         trials_df = pd.DataFrame(trials)
         trials = trials_df.pop("trial_id")


### PR DESCRIPTION
It is not possible to access params through function signiture, the key should be metric_str

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--551.org.readthedocs.build/en/551/

<!-- readthedocs-preview pytorch-tabular end -->