### PR TITLE
torch.load fix for all pytorch versions.

### DIFF
--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -761,9 +761,11 @@ class TabularDatamodule(pl.LightningDataModule):
                 # get the torch version
                 torch_version = torch.__version__
                 if torch_version < "2.6":
-                    dataset = torch.load(self.cache_dir / f"{tag}_dataset") # fix for torch version change of torch.load
+                    dataset = torch.load(
+                        self.cache_dir / f"{tag}_dataset"
+                    )  # fix for torch version change of torch.load
                 elif torch_version >= "2.6":
-                    dataset = torch.load(self.cache_dir / f"{tag}_dataset", weights_only=False)            
+                    dataset = torch.load(self.cache_dir / f"{tag}_dataset", weights_only=False)
             except FileNotFoundError:
                 raise FileNotFoundError(
                     f"{tag}_dataset not found in {self.cache_dir}. Please provide the" f" data for {tag} dataloader"

--- a/src/pytorch_tabular/tabular_datamodule.py
+++ b/src/pytorch_tabular/tabular_datamodule.py
@@ -758,7 +758,12 @@ class TabularDatamodule(pl.LightningDataModule):
                 )
         elif self.cache_mode is self.CACHE_MODES.DISK:
             try:
-                dataset = torch.load(self.cache_dir / f"{tag}_dataset", weights_only=False)
+                # get the torch version
+                torch_version = torch.__version__
+                if torch_version < "2.6":
+                    dataset = torch.load(self.cache_dir / f"{tag}_dataset") # fix for torch version change of torch.load
+                elif torch_version >= "2.6":
+                    dataset = torch.load(self.cache_dir / f"{tag}_dataset", weights_only=False)            
             except FileNotFoundError:
                 raise FileNotFoundError(
                     f"{tag}_dataset not found in {self.cache_dir}. Please provide the" f" data for {tag} dataloader"

--- a/src/pytorch_tabular/utils/python_utils.py
+++ b/src/pytorch_tabular/utils/python_utils.py
@@ -74,7 +74,12 @@ def pl_load(
     """
     if not isinstance(path_or_url, (str, Path)):
         # any sort of BytesIO or similar
-        return torch.load(path_or_url, map_location=map_location, weights_only=False)
+        # get the torch version
+        torch_version = torch.__version__
+        if torch_version < "2.6":
+            return torch.load(path_or_url, map_location=map_location) # for torch version < 2.6
+        elif torch_version >= "2.6":
+            return torch.load(path_or_url, map_location=map_location, weights_only=False)
     if str(path_or_url).startswith("http"):
         return torch.hub.load_state_dict_from_url(
             str(path_or_url),
@@ -82,7 +87,11 @@ def pl_load(
         )
     fs = get_filesystem(path_or_url)
     with fs.open(path_or_url, "rb") as f:
-        return torch.load(f, map_location=map_location, weights_only=False)
+        if torch_version < "2.6":
+            return torch.load(f, map_location=map_location) # for torch version < 2.6
+        elif torch_version >= "2.6":
+            return torch.load(f, map_location=map_location, weights_only=False)
+        
 
 
 def check_numpy(x):

--- a/src/pytorch_tabular/utils/python_utils.py
+++ b/src/pytorch_tabular/utils/python_utils.py
@@ -87,6 +87,7 @@ def pl_load(
         )
     fs = get_filesystem(path_or_url)
     with fs.open(path_or_url, "rb") as f:
+        torch_version = torch.__version__
         if torch_version < "2.6":
             return torch.load(f, map_location=map_location)  # for torch version < 2.6
         elif torch_version >= "2.6":

--- a/src/pytorch_tabular/utils/python_utils.py
+++ b/src/pytorch_tabular/utils/python_utils.py
@@ -77,7 +77,7 @@ def pl_load(
         # get the torch version
         torch_version = torch.__version__
         if torch_version < "2.6":
-            return torch.load(path_or_url, map_location=map_location) # for torch version < 2.6
+            return torch.load(path_or_url, map_location=map_location)  # for torch version < 2.6
         elif torch_version >= "2.6":
             return torch.load(path_or_url, map_location=map_location, weights_only=False)
     if str(path_or_url).startswith("http"):
@@ -88,10 +88,9 @@ def pl_load(
     fs = get_filesystem(path_or_url)
     with fs.open(path_or_url, "rb") as f:
         if torch_version < "2.6":
-            return torch.load(f, map_location=map_location) # for torch version < 2.6
+            return torch.load(f, map_location=map_location)  # for torch version < 2.6
         elif torch_version >= "2.6":
             return torch.load(f, map_location=map_location, weights_only=False)
-        
 
 
 def check_numpy(x):


### PR DESCRIPTION
This PR fixes the torch.load() bug for pytorch versions < 2.6 from the PR #543. The test cases for older versions of Python and by extension PyTorch were failing cause of the new change. [see here](https://github.com/manujosephv/pytorch_tabular/actions/runs/14014540640/job/39238518649?pr=540)

What this PR updates?
Catches pytorch version and uses the correct syntax for torch.load() to use in 
tabular_datamodule.py and python_ultis.py

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--554.org.readthedocs.build/en/554/

<!-- readthedocs-preview pytorch-tabular end -->