### PR TITLE
[MNT] improved `testing` CI job - `uv` and installed dependencies display

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -48,8 +48,9 @@ jobs:
         shell: python
 
       - name: Install main package & dependencies
-        run: |
-          uv pip install -e .[dev,extra]
+        run: uv pip install -e .[dev,extra]
+        env:
+          UV_SYSTEM_PYTHON: 1
 
       - name: Show installed packages
         run: uv pip list


### PR DESCRIPTION
Makes minor improvement to the main CI testing job `testing.yml`:

* change package manager to `uv`
* add step to display installed dependencies

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--599.org.readthedocs.build/en/599/

<!-- readthedocs-preview pytorch-tabular end -->