### PR TITLE
[MNT] reduce data size of test data to allow faster tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ if not os.path.isfile(DATASET_ZIP_OCCUPANCY):
 
 
 def load_regression_data():
-    DATA_SIZE= 500
+    DATA_SIZE = 200
     dataset = fetch_california_housing(data_home="data", as_frame=True)
     df = dataset.frame.sample(DATA_SIZE)
     df["HouseAgeBin"] = pd.qcut(df["HouseAge"], q=4)
@@ -32,7 +32,7 @@ def load_regression_data():
 
 
 def load_classification_data():
-    DATA_SIZE= 500
+    DATA_SIZE = 200
     dataset = fetch_covtype(data_home="data")
     data = np.hstack([dataset.data, dataset.target.reshape(-1, 1)])[:DATA_SIZE, :]
     col_names = [f"feature_{i}" for i in range(data.shape[-1])]


### PR DESCRIPTION
reduce data size of test data to allow faster test runs.

Before merging, it needs to be checked whether this is indeed the determinant parameter for test time, or not.

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--606.org.readthedocs.build/en/606/

<!-- readthedocs-preview pytorch-tabular end -->