### PR TITLE
[MNT] stop CI job that adds documentation build link to PR description

### DIFF
--- a/.github/workflows/documentation_links.yml
+++ b/.github/workflows/documentation_links.yml
@@ -1,8 +1,6 @@
 name: Read the Docs Pull Request Preview
 on:
-    pull_request_target:
-        types:
-            - opened
+    workflow_dispatch:
 
 permissions:
     pull-requests: write


### PR DESCRIPTION
this PR removes the trigger for the CI job that adds a documentation link to the PR description.

Reasons:

* the link is already present when clicking on the documentatino job
* the PR description is now used as a commit message when merged to `main`

<!-- readthedocs-preview pytorch-tabular start -->
----
📚 Documentation preview 📚: https://pytorch-tabular--608.org.readthedocs.build/en/608/

<!-- readthedocs-preview pytorch-tabular end -->