### PR TITLE
chore: Remove outdated ONNX export TODO

### DIFF
--- a/src/pytorch_tabular/tabular_model.py
+++ b/src/pytorch_tabular/tabular_model.py
@@ -1613,7 +1613,6 @@ class TabularModel:
         """
         self._load_weights(self.model, path)
 
-    # TODO Need to test ONNX export
     def save_model_for_inference(
         self,
         path: Union[str, Path],


### PR DESCRIPTION
This PR removes an outdated TODO comment regarding ONNX export testing, as comprehensive testing and validation for ONNX export was already implemented and merged in PR #660. Closes #661.